### PR TITLE
feat: expose a graphql endpoint in the nextjs package (pi-ui)

### DIFF
--- a/packages/pi-cli/package.json
+++ b/packages/pi-cli/package.json
@@ -14,7 +14,7 @@
     "detective": "./bin/index.js"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">= 16"
   },
   "author": "Gabriel J. Csapo <gabecsapo@gmail.com>",
   "license": "ISC",
@@ -39,5 +39,9 @@
     "jest": "^27.4.7",
     "package-json-type": "^1.0.3",
     "typescript": "^4.5.5"
+  },
+  "volta": {
+    "node": "16.14.2",
+    "yarn": "1.22.10"
   }
 }

--- a/packages/pi-cli/src/lib/dependencies.ts
+++ b/packages/pi-cli/src/lib/dependencies.ts
@@ -5,7 +5,12 @@ import { getBreadcrumb } from './utils/breadcrumb';
 import { getDirectorySize } from './utils/disk';
 import { getLatestPackages } from './utils/latest-packages';
 
-import { IReport, IArboristNode, DependenciesList } from '../types';
+import {
+  IReport,
+  IArboristNode,
+  Package,
+  PackageVersionByName,
+} from '../types';
 import {
   topLevelDepsFreshness,
   nestedDependencyFreshness,
@@ -31,33 +36,41 @@ export default async function generateReport(cwd: string): Promise<IReport> {
   });
   const rootArboristNode: IArboristNode = await arb.loadActual();
   const arboristValues = getValues(rootArboristNode);
-  const latestPackages = await getLatestPackages(arboristValues);
-  const dependencies: DependenciesList = [];
+  const latestPackagesMap = await getLatestPackages(arboristValues);
+  const latestPackages: PackageVersionByName[] = Object.keys(
+    latestPackagesMap
+  ).map((packageName) => {
+    return {
+      name: packageName,
+      version: latestPackagesMap[packageName],
+    };
+  });
+  const dependencies: Package[] = [];
 
   arboristValues.forEach((entryInfo) => {
-    dependencies.push([
-      entryInfo.path,
-      {
-        breadcrumb: getBreadcrumb(entryInfo),
-        funding: entryInfo.funding || 'N/A',
-        homepage: entryInfo.homepage || 'N/A',
-        // get the relative location to the project root
-        location: entryInfo.path
-          ? entryInfo.path.replace(process.cwd() + '/', '')
-          : 'N/A',
-        name: entryInfo.name,
-        version: entryInfo.version,
-        size: getDirectorySize({
-          directory: entryInfo.path,
-          exclude: new RegExp(path.resolve(entryInfo.path, 'node_modules')),
-        }),
-      },
-    ]);
+    dependencies.push({
+      pathOnDisk: entryInfo.path
+        ? entryInfo.path.replace(process.cwd() + '/', '')
+        : 'N/A',
+      breadcrumb: getBreadcrumb(entryInfo),
+      funding: entryInfo.funding || 'N/A',
+      homepage: entryInfo.homepage || 'N/A',
+      name: entryInfo.name,
+      version: entryInfo.version,
+      size: getDirectorySize({
+        directory: entryInfo.path,
+        exclude: new RegExp(path.resolve(entryInfo.path, 'node_modules')),
+      }),
+      // Get the correct values for these
+      dependencies: [],
+      devDependencies: [],
+    });
   });
 
   return {
     latestPackages,
-    package: rootArboristNode.package,
+    // fix this to be real
+    package: rootArboristNode.package as unknown as Package,
     dependencies,
     suggestions: [
       await packagesWithPinnedVersions({ arboristValues }),

--- a/packages/pi-cli/src/types.ts
+++ b/packages/pi-cli/src/types.ts
@@ -1,7 +1,5 @@
 import { IDependencyMap, IPackageJson } from 'package-json-type';
 
-export type DependenciesList = [string, IDependency][];
-
 export interface IArboristEdge {
   type: Set<string>;
   name: string;
@@ -45,16 +43,6 @@ export interface IArboristNode {
   version: string;
 }
 
-export interface IDependency {
-  breadcrumb: string;
-  funding?: string;
-  homepage?: string;
-  location: string;
-  version: string;
-  name: string;
-  size: number;
-}
-
 export interface IActionMeta {
   // where it exists in the tree (which dep brought this in) A->B->C
   breadcrumb: string;
@@ -88,9 +76,22 @@ export interface ISuggestion {
   actions: IAction[];
 }
 
+export interface Package
+  extends Pick<IPackageJson, 'name' | 'version' | 'funding' | 'homepage'> {
+  dependencies: Package[];
+  devDependencies: Package[];
+  pathOnDisk: string;
+  breadcrumb: string;
+  size: number;
+}
+
+export interface PackageVersionByName {
+  name: string;
+  version: string;
+}
 export interface IReport {
-  latestPackages: IDependencyMap;
-  package: IPackageJson;
-  dependencies: DependenciesList;
+  latestPackages: PackageVersionByName[];
+  package: Package;
+  dependencies: Package[];
   suggestions: ISuggestion[];
 }

--- a/packages/pi-ui/graphql/report.json
+++ b/packages/pi-ui/graphql/report.json
@@ -1,0 +1,13139 @@
+{
+  "latestPackages": [
+    { "name": "@ampproject/remapping", "version": "2.1.2" },
+    { "name": "@apollo/protobufjs", "version": "1.2.2" },
+    { "name": "@apollographql/apollo-tools", "version": "0.5.3" },
+    { "name": "@apollographql/graphql-playground-html", "version": "1.6.29" },
+    { "name": "@babel/code-frame", "version": "7.16.7" },
+    { "name": "@babel/compat-data", "version": "7.17.7" },
+    { "name": "@babel/core", "version": "7.17.9" },
+    { "name": "@babel/generator", "version": "7.17.9" },
+    { "name": "@babel/helper-compilation-targets", "version": "7.17.7" },
+    { "name": "@babel/helper-environment-visitor", "version": "7.16.7" },
+    { "name": "@babel/helper-function-name", "version": "7.17.9" },
+    { "name": "@babel/helper-hoist-variables", "version": "7.16.7" },
+    { "name": "@babel/helper-module-imports", "version": "7.16.7" },
+    { "name": "@babel/helper-module-transforms", "version": "7.17.7" },
+    { "name": "@babel/helper-plugin-utils", "version": "7.16.7" },
+    { "name": "@babel/helper-simple-access", "version": "7.17.7" },
+    { "name": "@babel/helper-split-export-declaration", "version": "7.16.7" },
+    { "name": "@babel/helper-validator-identifier", "version": "7.16.7" },
+    { "name": "@babel/helper-validator-option", "version": "7.16.7" },
+    { "name": "@babel/helpers", "version": "7.17.9" },
+    { "name": "@babel/highlight", "version": "7.17.9" },
+    { "name": "@babel/parser", "version": "7.17.9" },
+    { "name": "@babel/plugin-syntax-async-generators", "version": "7.8.4" },
+    { "name": "@babel/plugin-syntax-bigint", "version": "7.8.3" },
+    { "name": "@babel/plugin-syntax-class-properties", "version": "7.12.13" },
+    { "name": "@babel/plugin-syntax-import-meta", "version": "7.10.4" },
+    { "name": "@babel/plugin-syntax-json-strings", "version": "7.8.3" },
+    {
+      "name": "@babel/plugin-syntax-logical-assignment-operators",
+      "version": "7.10.4"
+    },
+    {
+      "name": "@babel/plugin-syntax-nullish-coalescing-operator",
+      "version": "7.8.3"
+    },
+    { "name": "@babel/plugin-syntax-numeric-separator", "version": "7.10.4" },
+    { "name": "@babel/plugin-syntax-object-rest-spread", "version": "7.8.3" },
+    {
+      "name": "@babel/plugin-syntax-optional-catch-binding",
+      "version": "7.8.3"
+    },
+    { "name": "@babel/plugin-syntax-optional-chaining", "version": "7.8.3" },
+    { "name": "@babel/plugin-syntax-top-level-await", "version": "7.14.5" },
+    { "name": "@babel/plugin-syntax-typescript", "version": "7.16.7" },
+    { "name": "@babel/runtime", "version": "7.17.9" },
+    { "name": "@babel/runtime-corejs3", "version": "7.17.9" },
+    { "name": "@babel/template", "version": "7.16.7" },
+    { "name": "@babel/traverse", "version": "7.17.9" },
+    { "name": "@babel/types", "version": "7.17.0" },
+    { "name": "@bcoe/v8-coverage", "version": "0.2.3" },
+    { "name": "@eslint/eslintrc", "version": "1.2.2" },
+    { "name": "@gar/promisify", "version": "1.1.3" },
+    { "name": "@graphql-tools/merge", "version": "8.2.10" },
+    { "name": "@graphql-tools/mock", "version": "8.6.8" },
+    { "name": "@graphql-tools/schema", "version": "8.3.10" },
+    { "name": "@graphql-tools/utils", "version": "8.6.9" },
+    { "name": "@hapi/accept", "version": "5.0.2" },
+    { "name": "@hapi/boom", "version": "9.1.4" },
+    { "name": "@hapi/hoek", "version": "9.2.1" },
+    { "name": "@humanwhocodes/config-array", "version": "0.10.2" },
+    { "name": "@humanwhocodes/object-schema", "version": "1.2.1" },
+    { "name": "@isaacs/string-locale-compare", "version": "1.1.0" },
+    { "name": "@istanbuljs/load-nyc-config", "version": "1.1.0" },
+    { "name": "@istanbuljs/schema", "version": "0.1.3" },
+    { "name": "@jest/console", "version": "28.0.0" },
+    { "name": "@jest/core", "version": "28.0.0" },
+    { "name": "@jest/environment", "version": "28.0.0" },
+    { "name": "@jest/fake-timers", "version": "28.0.0" },
+    { "name": "@jest/globals", "version": "28.0.0" },
+    { "name": "@jest/reporters", "version": "28.0.0" },
+    { "name": "@jest/source-map", "version": "28.0.0" },
+    { "name": "@jest/test-result", "version": "28.0.0" },
+    { "name": "@jest/test-sequencer", "version": "28.0.0" },
+    { "name": "@jest/transform", "version": "28.0.0" },
+    { "name": "@jest/types", "version": "28.0.0" },
+    { "name": "@josephg/resolvable", "version": "1.0.1" },
+    { "name": "@jridgewell/resolve-uri", "version": "3.0.6" },
+    { "name": "@jridgewell/sourcemap-codec", "version": "1.4.11" },
+    { "name": "@jridgewell/trace-mapping", "version": "0.3.9" },
+    { "name": "@next/env", "version": "12.1.5" },
+    { "name": "@next/eslint-plugin-next", "version": "12.1.5" },
+    { "name": "@next/swc-darwin-x64", "version": "11.1.2" },
+    { "name": "@nodelib/fs.scandir", "version": "2.1.5" },
+    { "name": "@nodelib/fs.stat", "version": "2.0.5" },
+    { "name": "@nodelib/fs.walk", "version": "1.2.8" },
+    { "name": "@npmcli/arborist", "version": "5.1.0" },
+    { "name": "@npmcli/fs", "version": "2.1.0" },
+    { "name": "@npmcli/git", "version": "3.0.1" },
+    { "name": "@npmcli/installed-package-contents", "version": "1.0.7" },
+    { "name": "@npmcli/map-workspaces", "version": "2.0.3" },
+    { "name": "@npmcli/metavuln-calculator", "version": "3.1.0" },
+    { "name": "@npmcli/move-file", "version": "2.0.0" },
+    { "name": "@npmcli/name-from-folder", "version": "1.0.1" },
+    { "name": "@npmcli/node-gyp", "version": "2.0.0" },
+    { "name": "@npmcli/package-json", "version": "2.0.0" },
+    { "name": "@npmcli/promise-spawn", "version": "3.0.0" },
+    { "name": "@npmcli/run-script", "version": "3.0.2" },
+    { "name": "@protobufjs/aspromise", "version": "1.1.2" },
+    { "name": "@protobufjs/base64", "version": "1.1.2" },
+    { "name": "@protobufjs/codegen", "version": "2.0.4" },
+    { "name": "@protobufjs/eventemitter", "version": "1.1.0" },
+    { "name": "@protobufjs/fetch", "version": "1.1.0" },
+    { "name": "@protobufjs/float", "version": "1.0.2" },
+    { "name": "@protobufjs/inquire", "version": "1.1.0" },
+    { "name": "@protobufjs/path", "version": "1.1.2" },
+    { "name": "@protobufjs/pool", "version": "1.1.0" },
+    { "name": "@protobufjs/utf8", "version": "1.1.0" },
+    { "name": "@rushstack/eslint-patch", "version": "1.1.3" },
+    { "name": "@sinonjs/commons", "version": "1.8.3" },
+    { "name": "@sinonjs/fake-timers", "version": "9.1.2" },
+    { "name": "@tootallnate/once", "version": "3.0.0" },
+    { "name": "@types/babel__core", "version": "7.1.19" },
+    { "name": "@types/babel__generator", "version": "7.6.4" },
+    { "name": "@types/babel__template", "version": "7.4.1" },
+    { "name": "@types/babel__traverse", "version": "7.17.0" },
+    { "name": "@types/debug", "version": "4.1.7" },
+    { "name": "@types/graceful-fs", "version": "4.1.5" },
+    { "name": "@types/istanbul-lib-coverage", "version": "2.0.4" },
+    { "name": "@types/istanbul-lib-report", "version": "3.0.0" },
+    { "name": "@types/istanbul-reports", "version": "3.0.1" },
+    { "name": "@types/jest", "version": "27.4.1" },
+    { "name": "@types/json-schema", "version": "7.0.11" },
+    { "name": "@types/json5", "version": "2.2.0" },
+    { "name": "@types/long", "version": "4.0.1" },
+    { "name": "@types/micro", "version": "7.3.7" },
+    { "name": "@types/micro-cors", "version": "0.1.2" },
+    { "name": "@types/ms", "version": "0.7.31" },
+    { "name": "@types/node", "version": "17.0.27" },
+    { "name": "@types/prettier", "version": "2.6.0" },
+    { "name": "@types/prop-types", "version": "15.7.5" },
+    { "name": "@types/react", "version": "18.0.7" },
+    { "name": "@types/react-dom", "version": "18.0.0" },
+    { "name": "@types/scheduler", "version": "0.16.2" },
+    { "name": "@types/semver", "version": "7.3.9" },
+    { "name": "@types/stack-utils", "version": "2.0.1" },
+    { "name": "@types/tmp", "version": "0.2.3" },
+    { "name": "@types/yargs", "version": "17.0.10" },
+    { "name": "@types/yargs-parser", "version": "21.0.0" },
+    { "name": "@typescript-eslint/eslint-plugin", "version": "5.21.0" },
+    { "name": "@typescript-eslint/parser", "version": "5.21.0" },
+    { "name": "@typescript-eslint/scope-manager", "version": "5.21.0" },
+    { "name": "@typescript-eslint/type-utils", "version": "5.21.0" },
+    { "name": "@typescript-eslint/types", "version": "5.21.0" },
+    { "name": "@typescript-eslint/typescript-estree", "version": "5.21.0" },
+    { "name": "@typescript-eslint/utils", "version": "5.21.0" },
+    { "name": "@typescript-eslint/visitor-keys", "version": "5.21.0" },
+    { "name": "abab", "version": "2.0.6" },
+    { "name": "abbrev", "version": "1.1.1" },
+    { "name": "acorn", "version": "8.7.0" },
+    { "name": "acorn-globals", "version": "6.0.0" },
+    { "name": "acorn-jsx", "version": "5.3.2" },
+    { "name": "acorn-walk", "version": "8.2.0" },
+    { "name": "agent-base", "version": "6.0.2" },
+    { "name": "agentkeepalive", "version": "4.2.1" },
+    { "name": "aggregate-error", "version": "4.0.0" },
+    { "name": "ajv", "version": "8.11.0" },
+    { "name": "ansi-escapes", "version": "5.0.0" },
+    { "name": "ansi-regex", "version": "6.0.1" },
+    { "name": "ansi-styles", "version": "6.1.0" },
+    { "name": "anymatch", "version": "3.1.2" },
+    { "name": "apollo-datasource", "version": "3.3.1" },
+    { "name": "apollo-reporting-protobuf", "version": "3.3.1" },
+    { "name": "apollo-server-caching", "version": "3.3.0" },
+    { "name": "apollo-server-core", "version": "3.6.7" },
+    { "name": "apollo-server-env", "version": "4.2.1" },
+    { "name": "apollo-server-errors", "version": "3.3.1" },
+    { "name": "apollo-server-micro", "version": "3.6.7" },
+    { "name": "apollo-server-plugin-base", "version": "3.5.2" },
+    { "name": "apollo-server-types", "version": "3.5.2" },
+    { "name": "aproba", "version": "2.0.0" },
+    { "name": "are-we-there-yet", "version": "3.0.0" },
+    { "name": "arg", "version": "5.0.1" },
+    { "name": "argparse", "version": "2.0.1" },
+    { "name": "aria-query", "version": "5.0.0" },
+    { "name": "array-includes", "version": "3.1.4" },
+    { "name": "array-union", "version": "3.0.1" },
+    { "name": "array.prototype.flat", "version": "1.3.0" },
+    { "name": "array.prototype.flatmap", "version": "1.3.0" },
+    { "name": "asap", "version": "2.0.6" },
+    { "name": "ast-types-flow", "version": "0.0.7" },
+    { "name": "astral-regex", "version": "2.0.0" },
+    { "name": "async-retry", "version": "1.3.3" },
+    { "name": "asynckit", "version": "0.4.0" },
+    { "name": "axe-core", "version": "4.4.1" },
+    { "name": "axobject-query", "version": "3.0.1" },
+    { "name": "babel-jest", "version": "28.0.0" },
+    { "name": "babel-plugin-istanbul", "version": "6.1.1" },
+    { "name": "babel-plugin-jest-hoist", "version": "28.0.0" },
+    { "name": "babel-preset-current-node-syntax", "version": "1.0.1" },
+    { "name": "babel-preset-jest", "version": "28.0.0" },
+    { "name": "balanced-match", "version": "2.0.0" },
+    { "name": "base64-js", "version": "1.5.1" },
+    { "name": "bin-links", "version": "3.0.1" },
+    { "name": "bl", "version": "5.0.0" },
+    { "name": "brace-expansion", "version": "2.0.1" },
+    { "name": "braces", "version": "3.0.2" },
+    { "name": "browser-process-hrtime", "version": "1.0.0" },
+    { "name": "browserslist", "version": "4.20.3" },
+    { "name": "bser", "version": "2.1.1" },
+    { "name": "buffer", "version": "6.0.3" },
+    { "name": "buffer-from", "version": "1.1.2" },
+    { "name": "builtins", "version": "5.0.1" },
+    { "name": "bytes", "version": "3.1.2" },
+    { "name": "cacache", "version": "16.0.6" },
+    { "name": "call-bind", "version": "1.0.2" },
+    { "name": "callsites", "version": "4.0.0" },
+    { "name": "camelcase", "version": "6.3.0" },
+    { "name": "caniuse-lite", "version": "1.0.30001332" },
+    { "name": "chalk", "version": "5.0.1" },
+    { "name": "char-regex", "version": "2.0.1" },
+    { "name": "chownr", "version": "2.0.0" },
+    { "name": "ci-info", "version": "3.3.0" },
+    { "name": "cjs-module-lexer", "version": "1.2.2" },
+    { "name": "clean-stack", "version": "4.1.0" },
+    { "name": "cli-cursor", "version": "4.0.0" },
+    { "name": "cli-spinners", "version": "2.6.1" },
+    { "name": "cli-truncate", "version": "3.1.0" },
+    { "name": "cliui", "version": "7.0.4" },
+    { "name": "clone", "version": "2.1.2" },
+    { "name": "cmd-shim", "version": "5.0.0" },
+    { "name": "co", "version": "4.6.0" },
+    { "name": "collect-v8-coverage", "version": "1.0.1" },
+    { "name": "color-convert", "version": "2.0.1" },
+    { "name": "color-name", "version": "1.1.4" },
+    { "name": "color-support", "version": "1.1.3" },
+    { "name": "colorette", "version": "2.0.16" },
+    { "name": "combined-stream", "version": "1.0.8" },
+    { "name": "commander", "version": "9.2.0" },
+    { "name": "common-ancestor-path", "version": "1.0.1" },
+    { "name": "concat-map", "version": "0.0.1" },
+    { "name": "console-control-strings", "version": "1.1.0" },
+    { "name": "content-type", "version": "1.0.4" },
+    { "name": "convert-source-map", "version": "1.8.0" },
+    { "name": "core-js-pure", "version": "3.22.2" },
+    { "name": "cross-spawn", "version": "7.0.3" },
+    { "name": "cssfilter", "version": "0.0.10" },
+    { "name": "cssom", "version": "0.5.0" },
+    { "name": "cssstyle", "version": "2.3.0" },
+    { "name": "csstype", "version": "3.0.11" },
+    { "name": "damerau-levenshtein", "version": "1.0.8" },
+    { "name": "data-urls", "version": "3.0.2" },
+    { "name": "debug", "version": "4.3.4" },
+    { "name": "debuglog", "version": "1.0.1" },
+    { "name": "decimal.js", "version": "10.3.1" },
+    { "name": "dedent", "version": "0.7.0" },
+    { "name": "deep-is", "version": "0.1.4" },
+    { "name": "deepmerge", "version": "4.2.2" },
+    { "name": "defaults", "version": "1.0.3" },
+    { "name": "define-properties", "version": "1.1.4" },
+    { "name": "delayed-stream", "version": "1.0.0" },
+    { "name": "delegates", "version": "1.0.0" },
+    { "name": "depd", "version": "2.0.0" },
+    { "name": "detect-newline", "version": "4.0.0" },
+    { "name": "dezalgo", "version": "1.0.4" },
+    { "name": "diff-sequences", "version": "28.0.0" },
+    { "name": "dir-glob", "version": "3.0.1" },
+    { "name": "doctrine", "version": "3.0.0" },
+    { "name": "domexception", "version": "4.0.0" },
+    { "name": "eastasianwidth", "version": "0.2.0" },
+    { "name": "electron-to-chromium", "version": "1.4.119" },
+    { "name": "emittery", "version": "0.10.2" },
+    { "name": "emoji-regex", "version": "10.1.0" },
+    { "name": "encoding", "version": "0.1.13" },
+    { "name": "env-paths", "version": "3.0.0" },
+    { "name": "err-code", "version": "3.0.1" },
+    { "name": "error-ex", "version": "1.3.2" },
+    { "name": "es-abstract", "version": "1.19.5" },
+    { "name": "es-shim-unscopables", "version": "1.0.0" },
+    { "name": "es-to-primitive", "version": "1.2.1" },
+    { "name": "escalade", "version": "3.1.1" },
+    { "name": "escape-string-regexp", "version": "5.0.0" },
+    { "name": "escodegen", "version": "2.0.0" },
+    { "name": "eslint", "version": "8.14.0" },
+    { "name": "eslint-config-next", "version": "12.1.5" },
+    { "name": "eslint-import-resolver-node", "version": "0.3.6" },
+    { "name": "eslint-import-resolver-typescript", "version": "2.7.1" },
+    { "name": "eslint-module-utils", "version": "2.7.3" },
+    { "name": "eslint-plugin-import", "version": "2.26.0" },
+    { "name": "eslint-plugin-jsx-a11y", "version": "6.5.1" },
+    { "name": "eslint-plugin-react", "version": "7.29.4" },
+    { "name": "eslint-plugin-react-hooks", "version": "4.4.0" },
+    { "name": "eslint-scope", "version": "7.1.1" },
+    { "name": "eslint-utils", "version": "3.0.0" },
+    { "name": "eslint-visitor-keys", "version": "3.3.0" },
+    { "name": "espree", "version": "9.3.1" },
+    { "name": "esprima", "version": "4.0.1" },
+    { "name": "esquery", "version": "1.4.0" },
+    { "name": "esrecurse", "version": "4.3.0" },
+    { "name": "estraverse", "version": "5.3.0" },
+    { "name": "esutils", "version": "2.0.3" },
+    { "name": "execa", "version": "6.1.0" },
+    { "name": "exit", "version": "0.1.2" },
+    { "name": "expect", "version": "28.0.0" },
+    { "name": "fast-deep-equal", "version": "3.1.3" },
+    { "name": "fast-glob", "version": "3.2.11" },
+    { "name": "fast-json-stable-stringify", "version": "2.1.0" },
+    { "name": "fast-levenshtein", "version": "3.0.0" },
+    { "name": "fastq", "version": "1.13.0" },
+    { "name": "fb-watchman", "version": "2.0.1" },
+    { "name": "file-entry-cache", "version": "6.0.1" },
+    { "name": "fill-range", "version": "7.0.1" },
+    { "name": "find-up", "version": "6.3.0" },
+    { "name": "flat-cache", "version": "3.0.4" },
+    { "name": "flatted", "version": "3.2.5" },
+    { "name": "form-data", "version": "4.0.0" },
+    { "name": "fs-minipass", "version": "2.1.0" },
+    { "name": "fs.realpath", "version": "1.0.0" },
+    { "name": "fsevents", "version": "2.3.2" },
+    { "name": "function-bind", "version": "1.1.1" },
+    { "name": "functional-red-black-tree", "version": "1.0.1" },
+    { "name": "functions-have-names", "version": "1.2.3" },
+    { "name": "gauge", "version": "4.0.4" },
+    { "name": "gensync", "version": "1.0.0-beta.2" },
+    { "name": "get-caller-file", "version": "2.0.5" },
+    { "name": "get-intrinsic", "version": "1.1.1" },
+    { "name": "get-package-type", "version": "0.1.0" },
+    { "name": "get-stream", "version": "6.0.1" },
+    { "name": "get-symbol-description", "version": "1.0.0" },
+    { "name": "glob", "version": "8.0.1" },
+    { "name": "glob-parent", "version": "6.0.2" },
+    { "name": "globals", "version": "13.13.0" },
+    { "name": "globby", "version": "13.1.1" },
+    { "name": "graceful-fs", "version": "4.2.10" },
+    { "name": "graphql", "version": "16.4.0" },
+    { "name": "graphql-tag", "version": "2.12.6" },
+    { "name": "has", "version": "1.0.3" },
+    { "name": "has-bigints", "version": "1.0.2" },
+    { "name": "has-flag", "version": "5.0.1" },
+    { "name": "has-property-descriptors", "version": "1.0.0" },
+    { "name": "has-symbols", "version": "1.0.3" },
+    { "name": "has-tostringtag", "version": "1.0.0" },
+    { "name": "has-unicode", "version": "2.0.1" },
+    { "name": "hosted-git-info", "version": "5.0.0" },
+    { "name": "html-encoding-sniffer", "version": "3.0.0" },
+    { "name": "html-escaper", "version": "3.0.3" },
+    { "name": "http-cache-semantics", "version": "4.1.0" },
+    { "name": "http-errors", "version": "2.0.0" },
+    { "name": "http-proxy-agent", "version": "5.0.0" },
+    { "name": "https-proxy-agent", "version": "5.0.1" },
+    { "name": "human-signals", "version": "3.0.1" },
+    { "name": "humanize-ms", "version": "1.2.1" },
+    { "name": "husky", "version": "7.0.4" },
+    { "name": "iconv-lite", "version": "0.6.3" },
+    { "name": "ieee754", "version": "1.2.1" },
+    { "name": "ignore", "version": "5.2.0" },
+    { "name": "ignore-walk", "version": "5.0.1" },
+    { "name": "import-fresh", "version": "3.3.0" },
+    { "name": "import-local", "version": "3.1.0" },
+    { "name": "imurmurhash", "version": "0.1.4" },
+    { "name": "indent-string", "version": "5.0.0" },
+    { "name": "infer-owner", "version": "1.0.4" },
+    { "name": "inflight", "version": "1.0.6" },
+    { "name": "inherits", "version": "2.0.4" },
+    { "name": "internal-slot", "version": "1.0.3" },
+    { "name": "ip", "version": "1.1.5" },
+    { "name": "is-arrayish", "version": "0.3.2" },
+    { "name": "is-bigint", "version": "1.0.4" },
+    { "name": "is-boolean-object", "version": "1.1.2" },
+    { "name": "is-callable", "version": "1.2.4" },
+    { "name": "is-core-module", "version": "2.9.0" },
+    { "name": "is-date-object", "version": "1.0.5" },
+    { "name": "is-extglob", "version": "2.1.1" },
+    { "name": "is-fullwidth-code-point", "version": "4.0.0" },
+    { "name": "is-generator-fn", "version": "3.0.0" },
+    { "name": "is-glob", "version": "4.0.3" },
+    { "name": "is-interactive", "version": "2.0.0" },
+    { "name": "is-lambda", "version": "1.0.1" },
+    { "name": "is-negative-zero", "version": "2.0.2" },
+    { "name": "is-number", "version": "7.0.0" },
+    { "name": "is-number-object", "version": "1.0.7" },
+    { "name": "is-potential-custom-element-name", "version": "1.0.1" },
+    { "name": "is-regex", "version": "1.1.4" },
+    { "name": "is-shared-array-buffer", "version": "1.0.2" },
+    { "name": "is-stream", "version": "3.0.0" },
+    { "name": "is-string", "version": "1.0.7" },
+    { "name": "is-symbol", "version": "1.0.4" },
+    { "name": "is-typedarray", "version": "1.0.0" },
+    { "name": "is-unicode-supported", "version": "1.2.0" },
+    { "name": "is-weakref", "version": "1.0.2" },
+    { "name": "isexe", "version": "2.0.0" },
+    { "name": "istanbul-lib-coverage", "version": "3.2.0" },
+    { "name": "istanbul-lib-instrument", "version": "5.2.0" },
+    { "name": "istanbul-lib-report", "version": "3.0.0" },
+    { "name": "istanbul-lib-source-maps", "version": "4.0.1" },
+    { "name": "istanbul-reports", "version": "3.1.4" },
+    { "name": "jest", "version": "28.0.0" },
+    { "name": "jest-changed-files", "version": "28.0.0" },
+    { "name": "jest-circus", "version": "28.0.0" },
+    { "name": "jest-cli", "version": "28.0.0" },
+    { "name": "jest-config", "version": "28.0.0" },
+    { "name": "jest-diff", "version": "28.0.0" },
+    { "name": "jest-docblock", "version": "28.0.0" },
+    { "name": "jest-each", "version": "28.0.0" },
+    { "name": "jest-environment-jsdom", "version": "28.0.0" },
+    { "name": "jest-environment-node", "version": "28.0.0" },
+    { "name": "jest-get-type", "version": "28.0.0" },
+    { "name": "jest-haste-map", "version": "28.0.0" },
+    { "name": "jest-jasmine2", "version": "28.0.0" },
+    { "name": "jest-leak-detector", "version": "28.0.0" },
+    { "name": "jest-matcher-utils", "version": "28.0.0" },
+    { "name": "jest-message-util", "version": "28.0.0" },
+    { "name": "jest-mock", "version": "28.0.0" },
+    { "name": "jest-pnp-resolver", "version": "1.2.2" },
+    { "name": "jest-regex-util", "version": "28.0.0" },
+    { "name": "jest-resolve", "version": "28.0.0" },
+    { "name": "jest-resolve-dependencies", "version": "28.0.0" },
+    { "name": "jest-runner", "version": "28.0.0" },
+    { "name": "jest-runtime", "version": "28.0.0" },
+    { "name": "jest-serializer", "version": "28.0.0" },
+    { "name": "jest-snapshot", "version": "28.0.0" },
+    { "name": "jest-util", "version": "28.0.0" },
+    { "name": "jest-validate", "version": "28.0.0" },
+    { "name": "jest-watcher", "version": "28.0.0" },
+    { "name": "jest-worker", "version": "28.0.0" },
+    { "name": "js-tokens", "version": "7.0.0" },
+    { "name": "js-yaml", "version": "4.1.0" },
+    { "name": "jsdom", "version": "19.0.0" },
+    { "name": "jsesc", "version": "3.0.2" },
+    { "name": "json-parse-even-better-errors", "version": "2.3.1" },
+    { "name": "json-schema-traverse", "version": "1.0.0" },
+    { "name": "json-stable-stringify-without-jsonify", "version": "1.0.1" },
+    { "name": "json-stringify-nice", "version": "1.1.4" },
+    { "name": "json5", "version": "2.2.1" },
+    { "name": "jsonparse", "version": "1.3.1" },
+    { "name": "jsx-ast-utils", "version": "3.2.2" },
+    { "name": "just-diff", "version": "5.0.1" },
+    { "name": "just-diff-apply", "version": "5.2.0" },
+    { "name": "kleur", "version": "4.1.4" },
+    { "name": "language-subtag-registry", "version": "0.3.21" },
+    { "name": "language-tags", "version": "1.0.5" },
+    { "name": "leven", "version": "4.0.0" },
+    { "name": "levn", "version": "0.4.1" },
+    { "name": "lilconfig", "version": "2.0.5" },
+    { "name": "lines-and-columns", "version": "2.0.3" },
+    { "name": "lint-staged", "version": "12.4.0" },
+    { "name": "listr2", "version": "4.0.5" },
+    { "name": "locate-path", "version": "7.1.0" },
+    { "name": "lodash", "version": "4.17.21" },
+    { "name": "lodash.merge", "version": "4.6.2" },
+    { "name": "lodash.sortby", "version": "4.7.0" },
+    { "name": "log-symbols", "version": "5.1.0" },
+    { "name": "log-update", "version": "5.0.1" },
+    { "name": "loglevel", "version": "1.8.0" },
+    { "name": "long", "version": "5.2.0" },
+    { "name": "loose-envify", "version": "1.4.0" },
+    { "name": "lru-cache", "version": "7.8.1" },
+    { "name": "make-dir", "version": "3.1.0" },
+    { "name": "make-fetch-happen", "version": "10.1.2" },
+    { "name": "makeerror", "version": "1.0.12" },
+    { "name": "media-typer", "version": "1.1.0" },
+    { "name": "merge-stream", "version": "2.0.0" },
+    { "name": "merge2", "version": "1.4.1" },
+    { "name": "micro", "version": "9.3.4" },
+    { "name": "micro-cors", "version": "0.1.1" },
+    { "name": "micromatch", "version": "4.0.5" },
+    { "name": "mime-db", "version": "1.52.0" },
+    { "name": "mime-types", "version": "2.1.35" },
+    { "name": "mimic-fn", "version": "4.0.0" },
+    { "name": "minimatch", "version": "5.0.1" },
+    { "name": "minimist", "version": "1.2.6" },
+    { "name": "minipass", "version": "3.1.6" },
+    { "name": "minipass-collect", "version": "1.0.2" },
+    { "name": "minipass-fetch", "version": "2.1.0" },
+    { "name": "minipass-flush", "version": "1.0.5" },
+    { "name": "minipass-json-stream", "version": "1.0.1" },
+    { "name": "minipass-pipeline", "version": "1.2.4" },
+    { "name": "minipass-sized", "version": "1.0.3" },
+    { "name": "minizlib", "version": "2.1.2" },
+    { "name": "mkdirp", "version": "1.0.4" },
+    { "name": "mkdirp-infer-owner", "version": "2.0.0" },
+    { "name": "ms", "version": "2.1.3" },
+    { "name": "nanoid", "version": "3.3.3" },
+    { "name": "natural-compare", "version": "1.4.0" },
+    { "name": "negotiator", "version": "0.6.3" },
+    { "name": "next", "version": "12.1.5" },
+    { "name": "node-fetch", "version": "3.2.3" },
+    { "name": "node-gyp", "version": "9.0.0" },
+    { "name": "node-int64", "version": "0.4.0" },
+    { "name": "node-releases", "version": "2.0.3" },
+    { "name": "nopt", "version": "5.0.0" },
+    { "name": "normalize-package-data", "version": "4.0.0" },
+    { "name": "normalize-path", "version": "3.0.0" },
+    { "name": "npm-bundled", "version": "1.1.2" },
+    { "name": "npm-install-checks", "version": "5.0.0" },
+    { "name": "npm-normalize-package-bin", "version": "1.0.1" },
+    { "name": "npm-package-arg", "version": "9.0.2" },
+    { "name": "npm-packlist", "version": "5.0.2" },
+    { "name": "npm-pick-manifest", "version": "7.0.1" },
+    { "name": "npm-registry-fetch", "version": "13.1.1" },
+    { "name": "npm-run-path", "version": "5.1.0" },
+    { "name": "npmlog", "version": "6.0.2" },
+    { "name": "nwsapi", "version": "2.2.0" },
+    { "name": "object-assign", "version": "4.1.1" },
+    { "name": "object-inspect", "version": "1.12.0" },
+    { "name": "object-keys", "version": "1.1.1" },
+    { "name": "object.assign", "version": "4.1.2" },
+    { "name": "object.entries", "version": "1.1.5" },
+    { "name": "object.fromentries", "version": "2.0.5" },
+    { "name": "object.hasown", "version": "1.1.0" },
+    { "name": "object.values", "version": "1.1.5" },
+    { "name": "once", "version": "1.4.0" },
+    { "name": "onetime", "version": "6.0.0" },
+    { "name": "optionator", "version": "0.9.1" },
+    { "name": "ora", "version": "6.1.0" },
+    { "name": "p-limit", "version": "4.0.0" },
+    { "name": "p-locate", "version": "6.0.0" },
+    { "name": "p-map", "version": "5.3.0" },
+    { "name": "p-try", "version": "3.0.0" },
+    { "name": "package-json-type", "version": "1.0.3" },
+    { "name": "pacote", "version": "13.1.1" },
+    { "name": "parent-module", "version": "3.0.0" },
+    { "name": "parse-conflict-json", "version": "2.0.2" },
+    { "name": "parse-json", "version": "6.0.2" },
+    { "name": "parse5", "version": "7.0.0" },
+    { "name": "path-exists", "version": "5.0.0" },
+    { "name": "path-is-absolute", "version": "2.0.0" },
+    { "name": "path-key", "version": "4.0.0" },
+    { "name": "path-parse", "version": "1.0.7" },
+    { "name": "path-type", "version": "5.0.0" },
+    { "name": "picocolors", "version": "1.0.0" },
+    { "name": "picomatch", "version": "2.3.1" },
+    { "name": "pidtree", "version": "0.5.0" },
+    { "name": "pirates", "version": "4.0.5" },
+    { "name": "pkg-dir", "version": "6.0.1" },
+    { "name": "postcss", "version": "8.4.12" },
+    { "name": "prelude-ls", "version": "1.2.1" },
+    { "name": "prettier", "version": "2.6.2" },
+    { "name": "pretty-format", "version": "28.0.0" },
+    { "name": "proc-log", "version": "2.0.1" },
+    { "name": "promise-all-reject-late", "version": "1.0.1" },
+    { "name": "promise-call-limit", "version": "1.0.1" },
+    { "name": "promise-inflight", "version": "1.0.1" },
+    { "name": "promise-retry", "version": "2.0.1" },
+    { "name": "prompts", "version": "2.4.2" },
+    { "name": "prop-types", "version": "15.8.1" },
+    { "name": "psl", "version": "1.8.0" },
+    { "name": "punycode", "version": "2.1.1" },
+    { "name": "queue-microtask", "version": "1.2.3" },
+    { "name": "raw-body", "version": "2.5.1" },
+    { "name": "react", "version": "18.0.0" },
+    { "name": "react-dom", "version": "18.0.0" },
+    { "name": "react-is", "version": "18.0.0" },
+    { "name": "read-cmd-shim", "version": "3.0.0" },
+    { "name": "read-package-json", "version": "5.0.1" },
+    { "name": "read-package-json-fast", "version": "2.0.3" },
+    { "name": "readable-stream", "version": "3.6.0" },
+    { "name": "readdir-scoped-modules", "version": "1.1.0" },
+    { "name": "regenerator-runtime", "version": "0.13.9" },
+    { "name": "regexp.prototype.flags", "version": "1.4.3" },
+    { "name": "regexpp", "version": "3.2.0" },
+    { "name": "require-directory", "version": "2.1.1" },
+    { "name": "resolve", "version": "1.22.0" },
+    { "name": "resolve-cwd", "version": "3.0.0" },
+    { "name": "resolve-from", "version": "5.0.0" },
+    { "name": "resolve.exports", "version": "1.1.0" },
+    { "name": "restore-cursor", "version": "4.0.0" },
+    { "name": "retry", "version": "0.13.1" },
+    { "name": "reusify", "version": "1.0.4" },
+    { "name": "rfdc", "version": "1.3.0" },
+    { "name": "rimraf", "version": "3.0.2" },
+    { "name": "run-parallel", "version": "1.2.0" },
+    { "name": "rxjs", "version": "7.5.5" },
+    { "name": "safe-buffer", "version": "5.2.1" },
+    { "name": "safer-buffer", "version": "2.1.2" },
+    { "name": "saxes", "version": "6.0.0" },
+    { "name": "scheduler", "version": "0.21.0" },
+    { "name": "semver", "version": "7.3.7" },
+    { "name": "set-blocking", "version": "2.0.0" },
+    { "name": "setprototypeof", "version": "1.2.0" },
+    { "name": "sha.js", "version": "2.4.11" },
+    { "name": "shebang-command", "version": "2.0.0" },
+    { "name": "shebang-regex", "version": "4.0.0" },
+    { "name": "side-channel", "version": "1.0.4" },
+    { "name": "signal-exit", "version": "3.0.7" },
+    { "name": "sisteransi", "version": "1.0.5" },
+    { "name": "slash", "version": "4.0.0" },
+    { "name": "slice-ansi", "version": "5.0.0" },
+    { "name": "smart-buffer", "version": "4.2.0" },
+    { "name": "socks", "version": "2.6.2" },
+    { "name": "socks-proxy-agent", "version": "6.2.0" },
+    { "name": "source-map", "version": "0.7.3" },
+    { "name": "source-map-js", "version": "1.0.2" },
+    { "name": "source-map-support", "version": "0.5.21" },
+    { "name": "spdx-correct", "version": "3.1.1" },
+    { "name": "spdx-exceptions", "version": "2.3.0" },
+    { "name": "spdx-expression-parse", "version": "3.0.1" },
+    { "name": "spdx-license-ids", "version": "3.0.11" },
+    { "name": "sprintf-js", "version": "1.1.2" },
+    { "name": "ssri", "version": "9.0.0" },
+    { "name": "stack-utils", "version": "2.0.5" },
+    { "name": "statuses", "version": "2.0.1" },
+    { "name": "string_decoder", "version": "1.3.0" },
+    { "name": "string-argv", "version": "0.3.1" },
+    { "name": "string-length", "version": "5.0.1" },
+    { "name": "string-width", "version": "5.1.2" },
+    { "name": "string.prototype.matchall", "version": "4.0.7" },
+    { "name": "string.prototype.trimend", "version": "1.0.4" },
+    { "name": "string.prototype.trimstart", "version": "1.0.4" },
+    { "name": "strip-ansi", "version": "7.0.1" },
+    { "name": "strip-bom", "version": "5.0.0" },
+    { "name": "strip-final-newline", "version": "3.0.0" },
+    { "name": "strip-json-comments", "version": "4.0.0" },
+    { "name": "styled-jsx", "version": "5.0.2" },
+    { "name": "supports-color", "version": "9.2.2" },
+    { "name": "supports-hyperlinks", "version": "2.2.0" },
+    { "name": "supports-preserve-symlinks-flag", "version": "1.0.0" },
+    { "name": "symbol-tree", "version": "3.2.4" },
+    { "name": "tar", "version": "6.1.11" },
+    { "name": "terminal-link", "version": "3.0.0" },
+    { "name": "test-exclude", "version": "6.0.0" },
+    { "name": "text-table", "version": "0.2.0" },
+    { "name": "throat", "version": "6.0.1" },
+    { "name": "through", "version": "2.3.8" },
+    { "name": "tmp", "version": "0.2.1" },
+    { "name": "tmpl", "version": "1.0.5" },
+    { "name": "to-fast-properties", "version": "4.0.0" },
+    { "name": "to-regex-range", "version": "5.0.1" },
+    { "name": "tough-cookie", "version": "4.0.0" },
+    { "name": "tr46", "version": "3.0.0" },
+    { "name": "treeverse", "version": "2.0.0" },
+    { "name": "tsconfig-paths", "version": "3.14.1" },
+    { "name": "tslib", "version": "2.4.0" },
+    { "name": "tsutils", "version": "3.21.0" },
+    { "name": "type-check", "version": "0.4.0" },
+    { "name": "type-detect", "version": "4.0.8" },
+    { "name": "type-fest", "version": "2.12.2" },
+    { "name": "type-is", "version": "1.6.18" },
+    { "name": "typedarray-to-buffer", "version": "4.0.0" },
+    { "name": "typescript", "version": "4.6.3" },
+    { "name": "unbox-primitive", "version": "1.0.2" },
+    { "name": "unique-filename", "version": "1.1.1" },
+    { "name": "unique-slug", "version": "2.0.2" },
+    { "name": "universalify", "version": "2.0.0" },
+    { "name": "unpipe", "version": "1.0.0" },
+    { "name": "uri-js", "version": "4.4.1" },
+    { "name": "util-deprecate", "version": "1.0.2" },
+    { "name": "uuid", "version": "8.3.2" },
+    { "name": "v8-compile-cache", "version": "2.3.0" },
+    { "name": "v8-to-istanbul", "version": "9.0.0" },
+    { "name": "validate-npm-package-license", "version": "3.0.4" },
+    { "name": "validate-npm-package-name", "version": "4.0.0" },
+    { "name": "value-or-promise", "version": "1.0.11" },
+    { "name": "w3c-hr-time", "version": "1.0.2" },
+    { "name": "w3c-xmlserializer", "version": "3.0.0" },
+    { "name": "walk-up-path", "version": "1.0.0" },
+    { "name": "walker", "version": "1.0.8" },
+    { "name": "wcwidth", "version": "1.0.1" },
+    { "name": "webidl-conversions", "version": "7.0.0" },
+    { "name": "whatwg-encoding", "version": "2.0.0" },
+    { "name": "whatwg-mimetype", "version": "3.0.0" },
+    { "name": "whatwg-url", "version": "11.0.0" },
+    { "name": "which", "version": "2.0.2" },
+    { "name": "which-boxed-primitive", "version": "1.0.2" },
+    { "name": "wide-align", "version": "1.1.5" },
+    { "name": "word-wrap", "version": "1.2.3" },
+    { "name": "wrap-ansi", "version": "8.0.1" },
+    { "name": "wrappy", "version": "1.0.2" },
+    { "name": "write-file-atomic", "version": "4.0.1" },
+    { "name": "ws", "version": "8.5.0" },
+    { "name": "xml-name-validator", "version": "4.0.0" },
+    { "name": "xmlchars", "version": "2.2.0" },
+    { "name": "xss", "version": "1.0.11" },
+    { "name": "y18n", "version": "5.0.8" },
+    { "name": "yallist", "version": "4.0.0" },
+    { "name": "yaml", "version": "2.0.1" },
+    { "name": "yargs", "version": "17.4.1" },
+    { "name": "yargs-parser", "version": "21.0.1" }
+  ],
+  "package": {
+    "name": "package-inspector",
+    "version": "0.0.1",
+    "description": "Tooling for inspecting your package",
+    "main": "index.js",
+    "repository": "git@github.com:es-maintenance/package-inspector.git",
+    "author": "Lewis Miller <lewis.miller.github@pm.me>",
+    "license": "MIT",
+    "private": true,
+    "workspaces": ["packages/*"],
+    "scripts": {
+      "dev": "yarn workspace @package-inspector/pi-ui dev",
+      "prepare": "husky install"
+    },
+    "devDependencies": {
+      "husky": "^7.0.4",
+      "lint-staged": "^12.4.0",
+      "prettier": "2.6.2"
+    },
+    "lint-staged": { "**/*": "prettier --write --ignore-unknown" },
+    "volta": { "node": "16.14.2", "yarn": "1.22.10" },
+    "_id": "package-inspector@0.0.1"
+  },
+  "dependencies": [
+    {
+      "pathOnDisk": "node_modules/abab",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#data-urls#abab",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "abab",
+      "version": "2.0.6",
+      "size": 10444,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/acorn",
+      "breadcrumb": "eslint-config-next#eslint#espree#acorn-jsx#acorn",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "acorn",
+      "version": "8.7.0",
+      "size": 465489,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/acorn-jsx",
+      "breadcrumb": "eslint-config-next#eslint#espree#acorn-jsx",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "acorn-jsx",
+      "version": "5.3.2",
+      "size": 24385,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/acorn-walk",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#acorn-globals#acorn-walk",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "acorn-walk",
+      "version": "7.2.0",
+      "size": 100036,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/acorn-globals",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#acorn-globals",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "acorn-globals",
+      "version": "6.0.0",
+      "size": 9103,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/abbrev",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#nopt#abbrev",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "abbrev",
+      "version": "1.1.1",
+      "size": 4782,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/agentkeepalive",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#agentkeepalive",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "agentkeepalive",
+      "version": "4.2.1",
+      "size": 38796,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/agent-base",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#http-proxy-agent#agent-base",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "agent-base",
+      "version": "6.0.2",
+      "size": 34582,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/aggregate-error",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#p-map#aggregate-error",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "aggregate-error",
+      "version": "3.1.0",
+      "size": 6690,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/ansi-escapes",
+      "breadcrumb": "jest#@jest/core#jest-watcher#ansi-escapes",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "ansi-escapes",
+      "version": "4.3.2",
+      "size": 16380,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/anymatch",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-resolve#jest-haste-map#anymatch",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "anymatch",
+      "version": "3.1.2",
+      "size": 9544,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/ansi-regex",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#pretty-format#ansi-regex",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "ansi-regex",
+      "version": "5.0.1",
+      "size": 5609,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/ajv",
+      "breadcrumb": "eslint-config-next#eslint#ajv",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "ajv",
+      "version": "6.12.6",
+      "size": 929154,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/apollo-datasource",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-datasource",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "apollo-datasource",
+      "version": "3.3.1",
+      "size": 3127,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/ansi-styles",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#chalk#ansi-styles",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "ansi-styles",
+      "version": "4.3.0",
+      "size": 16978,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/apollo-server-caching",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-caching",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "apollo-server-caching",
+      "version": "3.3.0",
+      "size": 23138,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/apollo-reporting-protobuf",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "apollo-reporting-protobuf",
+      "version": "3.3.1",
+      "size": 453528,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/apollo-server-core",
+      "breadcrumb": "apollo-server-micro#apollo-server-core",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "apollo-server-core",
+      "version": "3.6.7",
+      "size": 951728,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/apollo-server-errors",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-server-errors",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "apollo-server-errors",
+      "version": "3.3.1",
+      "size": 29663,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/apollo-server-micro",
+      "breadcrumb": "apollo-server-micro",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "apollo-server-micro",
+      "version": "3.6.7",
+      "size": 30467,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/apollo-server-plugin-base",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-server-plugin-base",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "apollo-server-plugin-base",
+      "version": "3.5.2",
+      "size": 14034,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/apollo-server-types",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-server-types",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "apollo-server-types",
+      "version": "3.5.2",
+      "size": 24742,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/apollo-server-env",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-env",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "apollo-server-env",
+      "version": "4.2.1",
+      "size": 17349,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/are-we-there-yet",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#npmlog#are-we-there-yet",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "are-we-there-yet",
+      "version": "3.0.0",
+      "size": 14230,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/arg",
+      "breadcrumb": "apollo-server-micro#micro#arg",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "arg",
+      "version": "4.1.0",
+      "size": 12592,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/aproba",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#npmlog#gauge#aproba",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "aproba",
+      "version": "2.0.0",
+      "size": 8047,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/argparse",
+      "breadcrumb": "eslint-config-next#eslint#js-yaml#argparse",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "argparse",
+      "version": "2.0.1",
+      "size": 171548,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/aria-query",
+      "breadcrumb": "eslint-config-next#eslint-plugin-jsx-a11y#aria-query",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "aria-query",
+      "version": "4.2.2",
+      "size": 171836,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/array-includes",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "array-includes",
+      "version": "3.1.4",
+      "size": 22369,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/array.prototype.flat",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array.prototype.flat",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "array.prototype.flat",
+      "version": "1.3.0",
+      "size": 16445,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/asap",
+      "breadcrumb": "@npmcli/arborist#readdir-scoped-modules#dezalgo#asap",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "asap",
+      "version": "2.0.6",
+      "size": 33916,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/array.prototype.flatmap",
+      "breadcrumb": "eslint-config-next#eslint-plugin-react#array.prototype.flatmap",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "array.prototype.flatmap",
+      "version": "1.3.0",
+      "size": 16574,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/astral-regex",
+      "breadcrumb": "lint-staged#listr2#cli-truncate#slice-ansi#astral-regex",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "astral-regex",
+      "version": "2.0.0",
+      "size": 3401,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/ast-types-flow",
+      "breadcrumb": "eslint-config-next#eslint-plugin-jsx-a11y#ast-types-flow",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "ast-types-flow",
+      "version": "0.0.7",
+      "size": 124577,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/asynckit",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#form-data#asynckit",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "asynckit",
+      "version": "0.4.0",
+      "size": 27362,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/async-retry",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#async-retry",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "async-retry",
+      "version": "1.3.3",
+      "size": 5215,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/axe-core",
+      "breadcrumb": "eslint-config-next#eslint-plugin-jsx-a11y#axe-core",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "axe-core",
+      "version": "4.4.1",
+      "size": 1884896,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/axobject-query",
+      "breadcrumb": "eslint-config-next#eslint-plugin-jsx-a11y#axobject-query",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "axobject-query",
+      "version": "2.2.0",
+      "size": 98753,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/babel-jest",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "babel-jest",
+      "version": "27.5.1",
+      "size": 14371,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/babel-plugin-istanbul",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "babel-plugin-istanbul",
+      "version": "6.1.1",
+      "size": 25722,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/array-union",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#array-union",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "array-union",
+      "version": "2.1.0",
+      "size": 3169,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/babel-plugin-jest-hoist",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-preset-jest#babel-plugin-jest-hoist",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "babel-plugin-jest-hoist",
+      "version": "27.5.1",
+      "size": 13673,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/babel-preset-current-node-syntax",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-preset-jest#babel-preset-current-node-syntax",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "babel-preset-current-node-syntax",
+      "version": "1.0.1",
+      "size": 5465,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/balanced-match",
+      "breadcrumb": "eslint-config-next#eslint#minimatch#brace-expansion#balanced-match",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "balanced-match",
+      "version": "1.0.2",
+      "size": 6939,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/base64-js",
+      "breadcrumb": "ora#bl#buffer#base64-js",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "base64-js",
+      "version": "1.5.1",
+      "size": 9624,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/bin-links",
+      "breadcrumb": "@npmcli/arborist#bin-links",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "bin-links",
+      "version": "3.0.1",
+      "size": 21189,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/babel-preset-jest",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-preset-jest",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "babel-preset-jest",
+      "version": "27.5.1",
+      "size": 2726,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/bl",
+      "breadcrumb": "ora#bl",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "bl",
+      "version": "4.1.0",
+      "size": 64427,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/brace-expansion",
+      "breadcrumb": "eslint-config-next#eslint#minimatch#brace-expansion",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "brace-expansion",
+      "version": "1.1.11",
+      "size": 11059,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/braces",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#fast-glob#micromatch#braces",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "braces",
+      "version": "3.0.2",
+      "size": 49239,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/browser-process-hrtime",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#w3c-hr-time#browser-process-hrtime",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "browser-process-hrtime",
+      "version": "1.0.0",
+      "size": 3525,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/browserslist",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#@babel/helper-compilation-targets#browserslist",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "browserslist",
+      "version": "4.20.3",
+      "size": 68520,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/bser",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-resolve#jest-haste-map#fb-watchman#bser",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "bser",
+      "version": "2.1.1",
+      "size": 17986,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/buffer",
+      "breadcrumb": "ora#bl#buffer",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "buffer",
+      "version": "5.7.1",
+      "size": 82527,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/buffer-from",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-runner#source-map-support#buffer-from",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "buffer-from",
+      "version": "1.1.2",
+      "size": 5047,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/builtins",
+      "breadcrumb": "@npmcli/arborist#pacote#npm-pick-manifest#npm-package-arg#validate-npm-package-name#builtins",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "builtins",
+      "version": "5.0.1",
+      "size": 3752,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/bytes",
+      "breadcrumb": "apollo-server-micro#micro#raw-body#bytes",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "bytes",
+      "version": "3.0.0",
+      "size": 10796,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/cacache",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "cacache",
+      "version": "16.0.6",
+      "size": 77252,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/call-bind",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#call-bind",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "call-bind",
+      "version": "1.0.2",
+      "size": 14748,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/callsites",
+      "breadcrumb": "eslint-config-next#eslint#import-fresh#parent-module#callsites",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "callsites",
+      "version": "3.1.0",
+      "size": 6332,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/camelcase",
+      "breadcrumb": "jest#jest-cli#jest-validate#camelcase",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "camelcase",
+      "version": "6.3.0",
+      "size": 11697,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/chalk",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#chalk",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "chalk",
+      "version": "4.1.2",
+      "size": 35047,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/caniuse-lite",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#@babel/helper-compilation-targets#browserslist#caniuse-lite",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "caniuse-lite",
+      "version": "1.0.30001332",
+      "size": 1501582,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/char-regex",
+      "breadcrumb": "jest#@jest/core#jest-watcher#string-length#char-regex",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "char-regex",
+      "version": "1.0.2",
+      "size": 4959,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/chownr",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#chownr",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "chownr",
+      "version": "2.0.0",
+      "size": 5748,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/ci-info",
+      "breadcrumb": "jest#jest-cli#jest-config#ci-info",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "ci-info",
+      "version": "3.3.0",
+      "size": 20082,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/clean-stack",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#p-map#aggregate-error#clean-stack",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "clean-stack",
+      "version": "2.2.0",
+      "size": 5508,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/cjs-module-lexer",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-runtime#cjs-module-lexer",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "cjs-module-lexer",
+      "version": "1.2.2",
+      "size": 138418,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/cli-spinners",
+      "breadcrumb": "ora#cli-spinners",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "cli-spinners",
+      "version": "2.6.1",
+      "size": 27522,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/cli-cursor",
+      "breadcrumb": "lint-staged#listr2#log-update#cli-cursor",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "cli-cursor",
+      "version": "3.1.0",
+      "size": 4372,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/cli-truncate",
+      "breadcrumb": "lint-staged#cli-truncate",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "cli-truncate",
+      "version": "3.1.0",
+      "size": 11422,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/cliui",
+      "breadcrumb": "yargs#cliui",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "cliui",
+      "version": "7.0.4",
+      "size": 30596,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/cmd-shim",
+      "breadcrumb": "@npmcli/arborist#bin-links#cmd-shim",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "cmd-shim",
+      "version": "5.0.0",
+      "size": 12101,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/co",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#co",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "co",
+      "version": "4.6.0",
+      "size": 16016,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/clone",
+      "breadcrumb": "ora#wcwidth#defaults#clone",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "clone",
+      "version": "1.0.4",
+      "size": 11132,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/color-convert",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#chalk#ansi-styles#color-convert",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "color-convert",
+      "version": "2.0.1",
+      "size": 27189,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/color-name",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#chalk#ansi-styles#color-convert#color-name",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "color-name",
+      "version": "1.1.4",
+      "size": 6693,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/color-support",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#npmlog#gauge#color-support",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "color-support",
+      "version": "1.1.3",
+      "size": 9233,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/colorette",
+      "breadcrumb": "lint-staged#colorette",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "colorette",
+      "version": "2.0.16",
+      "size": 16846,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/combined-stream",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#form-data#combined-stream",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "combined-stream",
+      "version": "1.0.8",
+      "size": 11514,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/commander",
+      "breadcrumb": "lint-staged#commander",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "commander",
+      "version": "8.3.0",
+      "size": 151267,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/concat-map",
+      "breadcrumb": "eslint-config-next#eslint#minimatch#brace-expansion#concat-map",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "concat-map",
+      "version": "0.0.1",
+      "size": 4861,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/console-control-strings",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#npmlog#gauge#console-control-strings",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "console-control-strings",
+      "version": "1.1.0",
+      "size": 12669,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/common-ancestor-path",
+      "breadcrumb": "@npmcli/arborist#common-ancestor-path",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "common-ancestor-path",
+      "version": "1.0.1",
+      "size": 2574,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/content-type",
+      "breadcrumb": "apollo-server-micro#micro#content-type",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "content-type",
+      "version": "1.0.4",
+      "size": 10200,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/convert-source-map",
+      "breadcrumb": "jest#@jest/core#@jest/reporters#v8-to-istanbul#convert-source-map",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "convert-source-map",
+      "version": "1.8.0",
+      "size": 10272,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/core-js-pure",
+      "breadcrumb": "eslint-config-next#eslint-plugin-jsx-a11y#aria-query#@babel/runtime-corejs3#core-js-pure",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "core-js-pure",
+      "version": "3.22.2",
+      "size": 866631,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/cross-spawn",
+      "breadcrumb": "eslint-config-next#eslint#cross-spawn",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "cross-spawn",
+      "version": "7.0.3",
+      "size": 21207,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/cssfilter",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#@apollographql/graphql-playground-html#xss#cssfilter",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "cssfilter",
+      "version": "0.0.10",
+      "size": 32015,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/cssom",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#cssom",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "cssom",
+      "version": "0.4.4",
+      "size": 48718,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/cssstyle",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#cssstyle",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "cssstyle",
+      "version": "2.3.0",
+      "size": 176221,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/csstype",
+      "breadcrumb": "@types/react-dom#@types/react#csstype",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "csstype",
+      "version": "3.0.11",
+      "size": 1199199,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/data-urls",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#data-urls",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "data-urls",
+      "version": "2.0.0",
+      "size": 8084,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/debuglog",
+      "breadcrumb": "@npmcli/arborist#readdir-scoped-modules#debuglog",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "debuglog",
+      "version": "1.0.1",
+      "size": 3348,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/damerau-levenshtein",
+      "breadcrumb": "eslint-config-next#eslint-plugin-jsx-a11y#damerau-levenshtein",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "damerau-levenshtein",
+      "version": "1.0.8",
+      "size": 11813,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/decimal.js",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#decimal.js",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "decimal.js",
+      "version": "10.3.1",
+      "size": 288297,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/defaults",
+      "breadcrumb": "ora#wcwidth#defaults",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "defaults",
+      "version": "1.0.3",
+      "size": 3768,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/debug",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#agentkeepalive#debug",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "debug",
+      "version": "4.3.4",
+      "size": 42352,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/dedent",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#dedent",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "dedent",
+      "version": "0.7.0",
+      "size": 4854,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/deepmerge",
+      "breadcrumb": "jest#jest-cli#jest-config#deepmerge",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "deepmerge",
+      "version": "4.2.2",
+      "size": 30093,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/deep-is",
+      "breadcrumb": "eslint-config-next#eslint#optionator#deep-is",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "deep-is",
+      "version": "0.1.4",
+      "size": 8114,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/collect-v8-coverage",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-runtime#collect-v8-coverage",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "collect-v8-coverage",
+      "version": "1.0.1",
+      "size": 4138,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/delegates",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#npmlog#are-we-there-yet#delegates",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "delegates",
+      "version": "1.0.0",
+      "size": 7459,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/delayed-stream",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#form-data#combined-stream#delayed-stream",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "delayed-stream",
+      "version": "1.0.0",
+      "size": 8021,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/depd",
+      "breadcrumb": "apollo-server-micro#micro#raw-body#http-errors#depd",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "depd",
+      "version": "1.1.1",
+      "size": 30486,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/define-properties",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#define-properties",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "define-properties",
+      "version": "1.1.4",
+      "size": 10361,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/diff-sequences",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-matcher-utils#jest-diff#diff-sequences",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "diff-sequences",
+      "version": "27.5.1",
+      "size": 53044,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/dezalgo",
+      "breadcrumb": "@npmcli/arborist#readdir-scoped-modules#dezalgo",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "dezalgo",
+      "version": "1.0.4",
+      "size": 2955,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/detect-newline",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-runner#jest-docblock#detect-newline",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "detect-newline",
+      "version": "3.1.0",
+      "size": 3774,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/doctrine",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#doctrine",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "doctrine",
+      "version": "2.1.0",
+      "size": 105957,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/dir-glob",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#dir-glob",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "dir-glob",
+      "version": "3.0.1",
+      "size": 5417,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/domexception",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#domexception",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "domexception",
+      "version": "2.0.1",
+      "size": 15542,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/electron-to-chromium",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#@babel/helper-compilation-targets#browserslist#electron-to-chromium",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "electron-to-chromium",
+      "version": "1.4.119",
+      "size": 164574,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eastasianwidth",
+      "breadcrumb": "lint-staged#cli-truncate#string-width#eastasianwidth",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "eastasianwidth",
+      "version": "0.2.0",
+      "size": 13640,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/emittery",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-runner#emittery",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "emittery",
+      "version": "0.8.1",
+      "size": 35534,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/emoji-regex",
+      "breadcrumb": "eslint-config-next#eslint-plugin-jsx-a11y#emoji-regex",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "emoji-regex",
+      "version": "9.2.2",
+      "size": 97916,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/encoding",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#minipass-fetch#encoding",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "encoding",
+      "version": "0.1.13",
+      "size": 7123,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/err-code",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#promise-retry#err-code",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "err-code",
+      "version": "2.0.3",
+      "size": 12280,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/error-ex",
+      "breadcrumb": "jest#jest-cli#jest-config#parse-json#error-ex",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "error-ex",
+      "version": "1.3.2",
+      "size": 9035,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/env-paths",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#env-paths",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "env-paths",
+      "version": "2.2.1",
+      "size": 10163,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/es-abstract",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "es-abstract",
+      "version": "1.19.5",
+      "size": 1160764,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/es-shim-unscopables",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array.prototype.flat#es-shim-unscopables",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "es-shim-unscopables",
+      "version": "1.0.0",
+      "size": 10023,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/es-to-primitive",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#es-to-primitive",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "es-to-primitive",
+      "version": "1.2.1",
+      "size": 40434,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/escalade",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#@babel/helper-compilation-targets#browserslist#escalade",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "escalade",
+      "version": "3.1.1",
+      "size": 11434,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/escape-string-regexp",
+      "breadcrumb": "eslint-config-next#eslint#escape-string-regexp",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "escape-string-regexp",
+      "version": "4.0.0",
+      "size": 3790,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/escodegen",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "escodegen",
+      "version": "2.0.0",
+      "size": 107797,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint",
+      "breadcrumb": "eslint-config-next#eslint",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "eslint",
+      "version": "8.14.0",
+      "size": 2715139,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-import-resolver-node",
+      "breadcrumb": "eslint-config-next#eslint-import-resolver-node",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "eslint-import-resolver-node",
+      "version": "0.3.4",
+      "size": 6802,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-config-next",
+      "breadcrumb": "eslint-config-next",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "eslint-config-next",
+      "version": "12.1.5",
+      "size": 5694,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-import-resolver-typescript",
+      "breadcrumb": "eslint-config-next#eslint-import-resolver-typescript",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "eslint-import-resolver-typescript",
+      "version": "2.4.0",
+      "size": 48419,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-module-utils",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-module-utils",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "eslint-module-utils",
+      "version": "2.7.3",
+      "size": 32144,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-plugin-import",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "eslint-plugin-import",
+      "version": "2.25.2",
+      "size": 1035171,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-plugin-jsx-a11y",
+      "breadcrumb": "eslint-config-next#eslint-plugin-jsx-a11y",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "eslint-plugin-jsx-a11y",
+      "version": "6.5.1",
+      "size": 635959,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-plugin-react",
+      "breadcrumb": "eslint-config-next#eslint-plugin-react",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "eslint-plugin-react",
+      "version": "7.29.1",
+      "size": 704508,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-plugin-react-hooks",
+      "breadcrumb": "eslint-config-next#eslint-plugin-react-hooks",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "eslint-plugin-react-hooks",
+      "version": "4.3.0",
+      "size": 117284,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-scope",
+      "breadcrumb": "eslint-config-next#eslint#eslint-scope",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "eslint-scope",
+      "version": "7.1.1",
+      "size": 145942,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-utils",
+      "breadcrumb": "eslint-config-next#eslint#eslint-utils",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "eslint-utils",
+      "version": "3.0.0",
+      "size": 358383,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-visitor-keys",
+      "breadcrumb": "eslint-config-next#eslint#eslint-visitor-keys",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "eslint-visitor-keys",
+      "version": "3.3.0",
+      "size": 31089,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/espree",
+      "breadcrumb": "eslint-config-next#eslint#espree",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "espree",
+      "version": "9.3.1",
+      "size": 75938,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/esprima",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#esprima",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "esprima",
+      "version": "4.0.1",
+      "size": 314361,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/esquery",
+      "breadcrumb": "eslint-config-next#eslint#esquery",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "esquery",
+      "version": "1.4.0",
+      "size": 986468,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/execa",
+      "breadcrumb": "jest#@jest/core#jest-changed-files#execa",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "execa",
+      "version": "5.1.1",
+      "size": 57525,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/exit",
+      "breadcrumb": "jest#jest-cli#exit",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "exit",
+      "version": "0.1.2",
+      "size": 59801,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/esutils",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#doctrine#esutils",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "esutils",
+      "version": "2.0.3",
+      "size": 50582,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/estraverse",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#estraverse",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "estraverse",
+      "version": "5.3.0",
+      "size": 37094,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/esrecurse",
+      "breadcrumb": "eslint-config-next#eslint#eslint-scope#esrecurse",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "esrecurse",
+      "version": "4.3.0",
+      "size": 13527,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/expect",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "expect",
+      "version": "27.5.1",
+      "size": 172096,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/fast-levenshtein",
+      "breadcrumb": "eslint-config-next#eslint#optionator#fast-levenshtein",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "fast-levenshtein",
+      "version": "2.0.6",
+      "size": 9444,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/fast-deep-equal",
+      "breadcrumb": "eslint-config-next#eslint#ajv#fast-deep-equal",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "fast-deep-equal",
+      "version": "3.1.3",
+      "size": 12966,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/fast-glob",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#fast-glob",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "fast-glob",
+      "version": "3.2.11",
+      "size": 88757,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/fb-watchman",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-resolve#jest-haste-map#fb-watchman",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "fb-watchman",
+      "version": "2.0.1",
+      "size": 10832,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/fast-json-stable-stringify",
+      "breadcrumb": "eslint-config-next#eslint#ajv#fast-json-stable-stringify",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "fast-json-stable-stringify",
+      "version": "2.1.0",
+      "size": 16959,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/fill-range",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#fast-glob#micromatch#braces#fill-range",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "fill-range",
+      "version": "7.0.1",
+      "size": 16351,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/fastq",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#fast-glob#@nodelib/fs.walk#fastq",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "fastq",
+      "version": "1.13.0",
+      "size": 38219,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/flat-cache",
+      "breadcrumb": "eslint-config-next#eslint#file-entry-cache#flat-cache",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "flat-cache",
+      "version": "3.0.4",
+      "size": 30009,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/find-up",
+      "breadcrumb": "jest#import-local#pkg-dir#find-up",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "find-up",
+      "version": "4.1.0",
+      "size": 11611,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/file-entry-cache",
+      "breadcrumb": "eslint-config-next#eslint#file-entry-cache",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "file-entry-cache",
+      "version": "6.0.1",
+      "size": 25561,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/flatted",
+      "breadcrumb": "eslint-config-next#eslint#file-entry-cache#flat-cache#flatted",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "flatted",
+      "version": "3.2.5",
+      "size": 78704,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/form-data",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#form-data",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "form-data",
+      "version": "3.0.1",
+      "size": 42729,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/fs-minipass",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#fs-minipass",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "fs-minipass",
+      "version": "2.1.0",
+      "size": 14089,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/fs.realpath",
+      "breadcrumb": "eslint-config-next#eslint-import-resolver-typescript#glob#fs.realpath",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "fs.realpath",
+      "version": "1.0.0",
+      "size": 13433,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/fsevents",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-resolve#jest-haste-map#fsevents",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "fsevents",
+      "version": "2.3.2",
+      "size": 156422,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/functions-have-names",
+      "breadcrumb": "eslint-config-next#eslint-plugin-react#string.prototype.matchall#regexp.prototype.flags#functions-have-names",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "functions-have-names",
+      "version": "1.2.3",
+      "size": 16715,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/gauge",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#npmlog#gauge",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "gauge",
+      "version": "4.0.4",
+      "size": 43163,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/function-bind",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#call-bind#function-bind",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "function-bind",
+      "version": "1.1.1",
+      "size": 25154,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/functional-red-black-tree",
+      "breadcrumb": "eslint-config-next#eslint#functional-red-black-tree",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "functional-red-black-tree",
+      "version": "1.0.1",
+      "size": 43457,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/gensync",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#gensync",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "gensync",
+      "version": "1.0.0-beta.2",
+      "size": 28891,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/get-caller-file",
+      "breadcrumb": "yargs#get-caller-file",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "get-caller-file",
+      "version": "2.0.5",
+      "size": 4719,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/get-intrinsic",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#get-intrinsic",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "get-intrinsic",
+      "version": "1.1.1",
+      "size": 32513,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/get-package-type",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@istanbuljs/load-nyc-config#get-package-type",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "get-package-type",
+      "version": "0.1.0",
+      "size": 6012,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/get-stream",
+      "breadcrumb": "jest#@jest/core#jest-changed-files#execa#get-stream",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "get-stream",
+      "version": "6.0.1",
+      "size": 12176,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/get-symbol-description",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#get-symbol-description",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "get-symbol-description",
+      "version": "1.0.0",
+      "size": 10267,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/glob",
+      "breadcrumb": "eslint-config-next#eslint-import-resolver-typescript#glob",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "glob",
+      "version": "7.2.0",
+      "size": 54742,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/glob-parent",
+      "breadcrumb": "eslint-config-next#eslint#glob-parent",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "glob-parent",
+      "version": "6.0.2",
+      "size": 7719,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/globals",
+      "breadcrumb": "eslint-config-next#eslint#globals",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "globals",
+      "version": "13.13.0",
+      "size": 45899,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/globby",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "globby",
+      "version": "11.1.0",
+      "size": 21758,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/graceful-fs",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#graceful-fs",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "graceful-fs",
+      "version": "4.2.10",
+      "size": 32470,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/graphql-tag",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#graphql-tag",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "graphql-tag",
+      "version": "2.12.6",
+      "size": 172138,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/has",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#has",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "has",
+      "version": "1.0.3",
+      "size": 2770,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/graphql",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#graphql",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "graphql",
+      "version": "16.4.0",
+      "size": 1338015,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/has-flag",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#chalk#supports-color#has-flag",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "has-flag",
+      "version": "4.0.0",
+      "size": 4419,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/has-bigints",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#unbox-primitive#which-boxed-primitive#is-bigint#has-bigints",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "has-bigints",
+      "version": "1.0.2",
+      "size": 12772,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/has-property-descriptors",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#define-properties#has-property-descriptors",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "has-property-descriptors",
+      "version": "1.0.0",
+      "size": 9308,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/has-symbols",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#has-symbols",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "has-symbols",
+      "version": "1.0.3",
+      "size": 20603,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/has-tostringtag",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#unbox-primitive#which-boxed-primitive#is-boolean-object#has-tostringtag",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "has-tostringtag",
+      "version": "1.0.0",
+      "size": 10887,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/has-unicode",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#npmlog#gauge#has-unicode",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "has-unicode",
+      "version": "2.0.1",
+      "size": 3436,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/hosted-git-info",
+      "breadcrumb": "@npmcli/arborist#pacote#read-package-json#normalize-package-data#hosted-git-info",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "hosted-git-info",
+      "version": "5.0.0",
+      "size": 24611,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/html-encoding-sniffer",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#html-encoding-sniffer",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "html-encoding-sniffer",
+      "version": "2.0.1",
+      "size": 11469,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/html-escaper",
+      "breadcrumb": "jest#@jest/core#@jest/reporters#istanbul-reports#html-escaper",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "html-escaper",
+      "version": "2.0.2",
+      "size": 13092,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/http-cache-semantics",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#http-cache-semantics",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "http-cache-semantics",
+      "version": "4.1.0",
+      "size": 36180,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/http-errors",
+      "breadcrumb": "apollo-server-micro#micro#raw-body#http-errors",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "http-errors",
+      "version": "1.6.2",
+      "size": 15660,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/http-proxy-agent",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#http-proxy-agent",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "http-proxy-agent",
+      "version": "5.0.0",
+      "size": 17084,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/https-proxy-agent",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#https-proxy-agent",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "https-proxy-agent",
+      "version": "5.0.1",
+      "size": 26008,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/human-signals",
+      "breadcrumb": "jest#@jest/core#jest-changed-files#execa#human-signals",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "human-signals",
+      "version": "2.1.0",
+      "size": 44307,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/humanize-ms",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#agentkeepalive#humanize-ms",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "humanize-ms",
+      "version": "1.2.1",
+      "size": 3656,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/husky",
+      "breadcrumb": "husky",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "husky",
+      "version": "7.0.4",
+      "size": 6058,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/iconv-lite",
+      "breadcrumb": "apollo-server-micro#micro#raw-body#iconv-lite",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "iconv-lite",
+      "version": "0.4.19",
+      "size": 335461,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/ignore",
+      "breadcrumb": "eslint-config-next#eslint#ignore",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "ignore",
+      "version": "5.2.0",
+      "size": 48870,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/ieee754",
+      "breadcrumb": "ora#bl#buffer#ieee754",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "ieee754",
+      "version": "1.2.1",
+      "size": 6796,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/ignore-walk",
+      "breadcrumb": "@npmcli/arborist#pacote#npm-packlist#ignore-walk",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "ignore-walk",
+      "version": "5.0.1",
+      "size": 12471,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/import-fresh",
+      "breadcrumb": "eslint-config-next#eslint#import-fresh",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "import-fresh",
+      "version": "3.3.0",
+      "size": 4866,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/imurmurhash",
+      "breadcrumb": "eslint-config-next#eslint#imurmurhash",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "imurmurhash",
+      "version": "0.1.4",
+      "size": 11887,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/import-local",
+      "breadcrumb": "jest#import-local",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "import-local",
+      "version": "3.1.0",
+      "size": 4658,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/infer-owner",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#infer-owner",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "infer-owner",
+      "version": "1.0.4",
+      "size": 4290,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/indent-string",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#p-map#aggregate-error#indent-string",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "indent-string",
+      "version": "4.0.0",
+      "size": 4398,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/inflight",
+      "breadcrumb": "eslint-config-next#eslint-import-resolver-typescript#glob#inflight",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "inflight",
+      "version": "1.0.6",
+      "size": 3762,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/inherits",
+      "breadcrumb": "ora#bl#inherits",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "inherits",
+      "version": "2.0.4",
+      "size": 3958,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-arrayish",
+      "breadcrumb": "jest#jest-cli#jest-config#parse-json#error-ex#is-arrayish",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-arrayish",
+      "version": "0.2.1",
+      "size": 4053,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/ip",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#socks-proxy-agent#socks#ip",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "ip",
+      "version": "1.1.5",
+      "size": 35730,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-bigint",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#unbox-primitive#which-boxed-primitive#is-bigint",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-bigint",
+      "version": "1.0.4",
+      "size": 14781,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-boolean-object",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#unbox-primitive#which-boxed-primitive#is-boolean-object",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-boolean-object",
+      "version": "1.1.2",
+      "size": 22120,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-callable",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#is-callable",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-callable",
+      "version": "1.2.4",
+      "size": 20069,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-core-module",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#is-core-module",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-core-module",
+      "version": "2.9.0",
+      "size": 26849,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-date-object",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#es-to-primitive#is-date-object",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-date-object",
+      "version": "1.0.5",
+      "size": 20793,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-extglob",
+      "breadcrumb": "eslint-config-next#eslint#is-glob#is-extglob",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-extglob",
+      "version": "2.1.1",
+      "size": 6217,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-fullwidth-code-point",
+      "breadcrumb": "yargs#cliui#string-width#is-fullwidth-code-point",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-fullwidth-code-point",
+      "version": "3.0.0",
+      "size": 4994,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/internal-slot",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#internal-slot",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "internal-slot",
+      "version": "1.0.3",
+      "size": 15457,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-generator-fn",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#is-generator-fn",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-generator-fn",
+      "version": "2.1.0",
+      "size": 3284,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-glob",
+      "breadcrumb": "eslint-config-next#eslint#is-glob",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-glob",
+      "version": "4.0.3",
+      "size": 13609,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-interactive",
+      "breadcrumb": "ora#is-interactive",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-interactive",
+      "version": "1.0.0",
+      "size": 4619,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-negative-zero",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#is-negative-zero",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-negative-zero",
+      "version": "2.0.2",
+      "size": 22002,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-potential-custom-element-name",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#is-potential-custom-element-name",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-potential-custom-element-name",
+      "version": "1.0.1",
+      "size": 3918,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-lambda",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#is-lambda",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-lambda",
+      "version": "1.0.1",
+      "size": 2944,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-number",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#fast-glob#micromatch#braces#fill-range#to-regex-range#is-number",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-number",
+      "version": "7.0.0",
+      "size": 9615,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-number-object",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#unbox-primitive#which-boxed-primitive#is-number-object",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-number-object",
+      "version": "1.0.7",
+      "size": 22218,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-shared-array-buffer",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#is-shared-array-buffer",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-shared-array-buffer",
+      "version": "1.0.2",
+      "size": 11886,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-stream",
+      "breadcrumb": "apollo-server-micro#micro#is-stream",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-stream",
+      "version": "1.1.0",
+      "size": 3234,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-string",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#is-string",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-string",
+      "version": "1.0.7",
+      "size": 19127,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-symbol",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#es-to-primitive#is-symbol",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-symbol",
+      "version": "1.0.4",
+      "size": 22031,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-typedarray",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@jest/transform#write-file-atomic#typedarray-to-buffer#is-typedarray",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-typedarray",
+      "version": "1.0.0",
+      "size": 4407,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-regex",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#is-regex",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-regex",
+      "version": "1.1.4",
+      "size": 30124,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-weakref",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#is-weakref",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-weakref",
+      "version": "1.0.2",
+      "size": 12065,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/is-unicode-supported",
+      "breadcrumb": "ora#log-symbols#is-unicode-supported",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-unicode-supported",
+      "version": "0.1.0",
+      "size": 3535,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/isexe",
+      "breadcrumb": "eslint-config-next#eslint#cross-spawn#which#isexe",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "isexe",
+      "version": "2.0.0",
+      "size": 10956,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/istanbul-lib-coverage",
+      "breadcrumb": "jest#@jest/core#@jest/reporters#istanbul-reports#istanbul-lib-report#istanbul-lib-coverage",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "istanbul-lib-coverage",
+      "version": "3.2.0",
+      "size": 29344,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/istanbul-lib-report",
+      "breadcrumb": "jest#@jest/core#@jest/reporters#istanbul-reports#istanbul-lib-report",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "istanbul-lib-report",
+      "version": "3.0.0",
+      "size": 37452,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/istanbul-lib-instrument",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#istanbul-lib-instrument",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "istanbul-lib-instrument",
+      "version": "5.2.0",
+      "size": 69302,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/istanbul-lib-source-maps",
+      "breadcrumb": "jest#@jest/core#@jest/reporters#istanbul-lib-source-maps",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "istanbul-lib-source-maps",
+      "version": "4.0.1",
+      "size": 34127,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/istanbul-reports",
+      "breadcrumb": "jest#@jest/core#@jest/reporters#istanbul-reports",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "istanbul-reports",
+      "version": "3.1.4",
+      "size": 291009,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest",
+      "breadcrumb": "jest",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest",
+      "version": "27.5.1",
+      "size": 4740,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-changed-files",
+      "breadcrumb": "jest#@jest/core#jest-changed-files",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-changed-files",
+      "version": "27.5.1",
+      "size": 15095,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-circus",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-circus",
+      "version": "27.5.1",
+      "size": 78131,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-cli",
+      "breadcrumb": "jest#jest-cli",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-cli",
+      "version": "27.5.1",
+      "size": 60836,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-config",
+      "breadcrumb": "jest#jest-cli#jest-config",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-config",
+      "version": "27.5.1",
+      "size": 112069,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-diff",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-matcher-utils#jest-diff",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-diff",
+      "version": "27.5.1",
+      "size": 85165,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-docblock",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-runner#jest-docblock",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-docblock",
+      "version": "27.5.1",
+      "size": 9080,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-each",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-each",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-each",
+      "version": "27.5.1",
+      "size": 39856,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-environment-jsdom",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-environment-jsdom",
+      "version": "27.5.1",
+      "size": 8101,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-environment-node",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-node",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-environment-node",
+      "version": "27.5.1",
+      "size": 7320,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-get-type",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-get-type",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-get-type",
+      "version": "27.5.1",
+      "size": 3815,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-haste-map",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-resolve#jest-haste-map",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-haste-map",
+      "version": "27.5.1",
+      "size": 135137,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-jasmine2",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-jasmine2",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-jasmine2",
+      "version": "27.5.1",
+      "size": 137046,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-leak-detector",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-runner#jest-leak-detector",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-leak-detector",
+      "version": "27.5.1",
+      "size": 5751,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-message-util",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-message-util",
+      "version": "27.5.1",
+      "size": 18054,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-matcher-utils",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-matcher-utils",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-matcher-utils",
+      "version": "27.5.1",
+      "size": 28610,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-mock",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jest-mock",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-mock",
+      "version": "27.5.1",
+      "size": 39081,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-pnp-resolver",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-resolve#jest-pnp-resolver",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-pnp-resolver",
+      "version": "1.2.2",
+      "size": 5705,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-regex-util",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-regex-util",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-regex-util",
+      "version": "27.5.1",
+      "size": 3368,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-resolve",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-resolve",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-resolve",
+      "version": "27.5.1",
+      "size": 52869,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-resolve-dependencies",
+      "breadcrumb": "jest#@jest/core#jest-resolve-dependencies",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-resolve-dependencies",
+      "version": "27.5.1",
+      "size": 9111,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-runtime",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-runtime",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-runtime",
+      "version": "27.5.1",
+      "size": 82000,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-serializer",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-resolve#jest-haste-map#jest-serializer",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-serializer",
+      "version": "27.5.1",
+      "size": 7120,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-runner",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-runner",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-runner",
+      "version": "27.5.1",
+      "size": 30758,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-util",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-util",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-util",
+      "version": "27.5.1",
+      "size": 41939,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-validate",
+      "breadcrumb": "jest#jest-cli#jest-validate",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-validate",
+      "version": "27.5.1",
+      "size": 31956,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-snapshot",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-snapshot",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-snapshot",
+      "version": "27.5.1",
+      "size": 93243,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-worker",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-resolve#jest-haste-map#jest-worker",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-worker",
+      "version": "27.5.1",
+      "size": 81896,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/js-tokens",
+      "breadcrumb": "eslint-config-next#eslint-plugin-react#prop-types#loose-envify#js-tokens",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "js-tokens",
+      "version": "4.0.0",
+      "size": 15069,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-watcher",
+      "breadcrumb": "jest#@jest/core#jest-watcher",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jest-watcher",
+      "version": "27.5.1",
+      "size": 26734,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/js-yaml",
+      "breadcrumb": "eslint-config-next#eslint#js-yaml",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "js-yaml",
+      "version": "4.1.0",
+      "size": 404738,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/json-parse-even-better-errors",
+      "breadcrumb": "@npmcli/arborist#parse-conflict-json#json-parse-even-better-errors",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "json-parse-even-better-errors",
+      "version": "2.3.1",
+      "size": 10426,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jsdom",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jsdom",
+      "version": "16.7.0",
+      "size": 2769471,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jsesc",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-snapshot#@babel/generator#jsesc",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jsesc",
+      "version": "2.5.2",
+      "size": 31974,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/json-schema-traverse",
+      "breadcrumb": "eslint-config-next#eslint#ajv#json-schema-traverse",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "json-schema-traverse",
+      "version": "0.4.1",
+      "size": 19564,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/json-stringify-nice",
+      "breadcrumb": "@npmcli/arborist#json-stringify-nice",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "json-stringify-nice",
+      "version": "1.1.4",
+      "size": 5686,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/json-stable-stringify-without-jsonify",
+      "breadcrumb": "eslint-config-next#eslint#json-stable-stringify-without-jsonify",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "json-stable-stringify-without-jsonify",
+      "version": "1.0.1",
+      "size": 14224,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/json5",
+      "breadcrumb": "eslint-config-next#eslint-import-resolver-typescript#tsconfig-paths#json5",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "json5",
+      "version": "1.0.1",
+      "size": 88338,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jsx-ast-utils",
+      "breadcrumb": "eslint-config-next#eslint-plugin-jsx-a11y#jsx-ast-utils",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jsx-ast-utils",
+      "version": "3.2.2",
+      "size": 225940,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jsonparse",
+      "breadcrumb": "@npmcli/arborist#pacote#npm-registry-fetch#minipass-json-stream#jsonparse",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "jsonparse",
+      "version": "1.3.1",
+      "size": 36779,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/just-diff",
+      "breadcrumb": "@npmcli/arborist#parse-conflict-json#just-diff",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "just-diff",
+      "version": "5.0.1",
+      "size": 13405,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/kleur",
+      "breadcrumb": "jest#jest-cli#prompts#kleur",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "kleur",
+      "version": "3.0.3",
+      "size": 9893,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/just-diff-apply",
+      "breadcrumb": "@npmcli/arborist#parse-conflict-json#just-diff-apply",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "just-diff-apply",
+      "version": "5.2.0",
+      "size": 14087,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/language-subtag-registry",
+      "breadcrumb": "eslint-config-next#eslint-plugin-jsx-a11y#language-tags#language-subtag-registry",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "language-subtag-registry",
+      "version": "0.3.21",
+      "size": 1536902,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/language-tags",
+      "breadcrumb": "eslint-config-next#eslint-plugin-jsx-a11y#language-tags",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "language-tags",
+      "version": "1.0.5",
+      "size": 48834,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/levn",
+      "breadcrumb": "eslint-config-next#eslint#levn",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "levn",
+      "version": "0.4.1",
+      "size": 24947,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/leven",
+      "breadcrumb": "jest#jest-cli#jest-validate#leven",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "leven",
+      "version": "3.1.0",
+      "size": 5342,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/lilconfig",
+      "breadcrumb": "lint-staged#lilconfig",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "lilconfig",
+      "version": "2.0.4",
+      "size": 14779,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/lines-and-columns",
+      "breadcrumb": "jest#jest-cli#jest-config#parse-json#lines-and-columns",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "lines-and-columns",
+      "version": "1.2.4",
+      "size": 5386,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/lint-staged",
+      "breadcrumb": "lint-staged",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "lint-staged",
+      "version": "12.4.0",
+      "size": 102103,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/listr2",
+      "breadcrumb": "lint-staged#listr2",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "listr2",
+      "version": "4.0.5",
+      "size": 184201,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/locate-path",
+      "breadcrumb": "jest#import-local#pkg-dir#find-up#locate-path",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "locate-path",
+      "version": "5.0.0",
+      "size": 6584,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/lodash",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#data-urls#whatwg-url#lodash",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "lodash",
+      "version": "4.17.21",
+      "size": 1412415,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/lodash.merge",
+      "breadcrumb": "eslint-config-next#eslint#lodash.merge",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "lodash.merge",
+      "version": "4.6.2",
+      "size": 54132,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/lodash.sortby",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#lodash.sortby",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "lodash.sortby",
+      "version": "4.7.0",
+      "size": 75755,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/log-symbols",
+      "breadcrumb": "ora#log-symbols",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "log-symbols",
+      "version": "4.1.0",
+      "size": 4580,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/log-update",
+      "breadcrumb": "lint-staged#listr2#log-update",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "log-update",
+      "version": "4.0.0",
+      "size": 7575,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/long",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#long",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "long",
+      "version": "4.0.0",
+      "size": 176654,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/loglevel",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#loglevel",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "loglevel",
+      "version": "1.8.0",
+      "size": 139230,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/loose-envify",
+      "breadcrumb": "eslint-config-next#eslint-plugin-react#prop-types#loose-envify",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "loose-envify",
+      "version": "1.4.0",
+      "size": 5814,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/lru-cache",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#lru-cache",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "lru-cache",
+      "version": "7.8.1",
+      "size": 50892,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/make-dir",
+      "breadcrumb": "jest#@jest/core#@jest/reporters#istanbul-reports#istanbul-lib-report#make-dir",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "make-dir",
+      "version": "3.1.0",
+      "size": 10042,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/media-typer",
+      "breadcrumb": "apollo-server-micro#type-is#media-typer",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "media-typer",
+      "version": "0.3.0",
+      "size": 11055,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/make-fetch-happen",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "make-fetch-happen",
+      "version": "10.1.2",
+      "size": 59352,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/makeerror",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-resolve#jest-haste-map#walker#makeerror",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "makeerror",
+      "version": "1.0.12",
+      "size": 6073,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/merge-stream",
+      "breadcrumb": "jest#@jest/core#jest-changed-files#execa#merge-stream",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "merge-stream",
+      "version": "2.0.0",
+      "size": 4306,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/merge2",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#fast-glob#merge2",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "merge2",
+      "version": "1.4.1",
+      "size": 8897,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/micro",
+      "breadcrumb": "apollo-server-micro#micro",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "micro",
+      "version": "9.3.4",
+      "size": 26287,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/micro-cors",
+      "breadcrumb": "micro-cors",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "micro-cors",
+      "version": "0.1.1",
+      "size": 5665,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/micromatch",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#fast-glob#micromatch",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "micromatch",
+      "version": "4.0.5",
+      "size": 55947,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/mime-db",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#form-data#mime-types#mime-db",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "mime-db",
+      "version": "1.52.0",
+      "size": 205539,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/mimic-fn",
+      "breadcrumb": "jest#@jest/core#jest-changed-files#execa#onetime#mimic-fn",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "mimic-fn",
+      "version": "2.1.0",
+      "size": 4457,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/mime-types",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#form-data#mime-types",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "mime-types",
+      "version": "2.1.35",
+      "size": 18272,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/minimatch",
+      "breadcrumb": "eslint-config-next#eslint#minimatch",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "minimatch",
+      "version": "3.1.2",
+      "size": 34902,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/minimist",
+      "breadcrumb": "eslint-config-next#eslint-import-resolver-typescript#tsconfig-paths#json5#minimist",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "minimist",
+      "version": "1.2.6",
+      "size": 33202,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/minipass-collect",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#minipass-collect",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "minipass-collect",
+      "version": "1.0.2",
+      "size": 4870,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/minipass",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#minipass",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "minipass",
+      "version": "3.1.6",
+      "size": 37791,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/minipass-fetch",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#minipass-fetch",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "minipass-fetch",
+      "version": "2.1.0",
+      "size": 46245,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/minipass-flush",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#minipass-flush",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "minipass-flush",
+      "version": "1.0.5",
+      "size": 3771,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/minipass-json-stream",
+      "breadcrumb": "@npmcli/arborist#pacote#npm-registry-fetch#minipass-json-stream",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "minipass-json-stream",
+      "version": "1.0.1",
+      "size": 13013,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/minipass-pipeline",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#minipass-pipeline",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "minipass-pipeline",
+      "version": "1.2.4",
+      "size": 7004,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/minipass-sized",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#minipass-fetch#minipass-sized",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "minipass-sized",
+      "version": "1.0.3",
+      "size": 123865,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/minizlib",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#minipass-fetch#minizlib",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "minizlib",
+      "version": "2.1.2",
+      "size": 17309,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/mkdirp",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#mkdirp",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "mkdirp",
+      "version": "1.0.4",
+      "size": 19088,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/ms",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#agentkeepalive#humanize-ms#ms",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "ms",
+      "version": "2.1.3",
+      "size": 6721,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/mkdirp-infer-owner",
+      "breadcrumb": "@npmcli/arborist#bin-links#mkdirp-infer-owner",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "mkdirp-infer-owner",
+      "version": "2.0.0",
+      "size": 3188,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/nanoid",
+      "breadcrumb": "eslint-config-next#next#postcss#nanoid",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "nanoid",
+      "version": "3.3.3",
+      "size": 21579,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/natural-compare",
+      "breadcrumb": "eslint-config-next#eslint#natural-compare",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "natural-compare",
+      "version": "1.4.0",
+      "size": 5647,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/next",
+      "breadcrumb": "eslint-config-next#next",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "next",
+      "version": "12.1.5",
+      "size": 31562793,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/negotiator",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#negotiator",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "negotiator",
+      "version": "0.6.3",
+      "size": 27375,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/node-fetch",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-env#node-fetch",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "node-fetch",
+      "version": "2.6.7",
+      "size": 152240,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/node-gyp",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "node-gyp",
+      "version": "9.0.0",
+      "size": 1984092,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/node-int64",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-resolve#jest-haste-map#fb-watchman#bser#node-int64",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "node-int64",
+      "version": "0.4.0",
+      "size": 16268,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/node-releases",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#@babel/helper-compilation-targets#browserslist#node-releases",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "node-releases",
+      "version": "2.0.3",
+      "size": 24358,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/normalize-package-data",
+      "breadcrumb": "@npmcli/arborist#pacote#read-package-json#normalize-package-data",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "normalize-package-data",
+      "version": "4.0.0",
+      "size": 27914,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/nopt",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#nopt",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "nopt",
+      "version": "5.0.0",
+      "size": 25840,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/normalize-path",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-resolve#jest-haste-map#anymatch#normalize-path",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "normalize-path",
+      "version": "3.0.0",
+      "size": 9219,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/npm-bundled",
+      "breadcrumb": "@npmcli/arborist#pacote#npm-packlist#npm-bundled",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "npm-bundled",
+      "version": "1.1.2",
+      "size": 9743,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/npm-normalize-package-bin",
+      "breadcrumb": "@npmcli/arborist#bin-links#npm-normalize-package-bin",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "npm-normalize-package-bin",
+      "version": "1.0.1",
+      "size": 131250,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/npm-install-checks",
+      "breadcrumb": "@npmcli/arborist#pacote#npm-pick-manifest#npm-install-checks",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "npm-install-checks",
+      "version": "5.0.0",
+      "size": 5164,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/npm-packlist",
+      "breadcrumb": "@npmcli/arborist#pacote#npm-packlist",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "npm-packlist",
+      "version": "5.0.2",
+      "size": 24122,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/npm-pick-manifest",
+      "breadcrumb": "@npmcli/arborist#pacote#npm-pick-manifest",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "npm-pick-manifest",
+      "version": "7.0.1",
+      "size": 16324,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/npm-package-arg",
+      "breadcrumb": "@npmcli/arborist#pacote#npm-pick-manifest#npm-package-arg",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "npm-package-arg",
+      "version": "9.0.2",
+      "size": 17396,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/npm-registry-fetch",
+      "breadcrumb": "@npmcli/arborist#pacote#npm-registry-fetch",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "npm-registry-fetch",
+      "version": "13.1.1",
+      "size": 37517,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/npm-run-path",
+      "breadcrumb": "jest#@jest/core#jest-changed-files#execa#npm-run-path",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "npm-run-path",
+      "version": "4.0.1",
+      "size": 8128,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/npmlog",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#npmlog",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "npmlog",
+      "version": "6.0.2",
+      "size": 17096,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/nwsapi",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#nwsapi",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "nwsapi",
+      "version": "2.2.0",
+      "size": 80523,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/object-assign",
+      "breadcrumb": "eslint-config-next#eslint-plugin-react#prop-types#object-assign",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "object-assign",
+      "version": "4.1.1",
+      "size": 5493,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/object-inspect",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#object-inspect",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "object-inspect",
+      "version": "1.12.0",
+      "size": 90592,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/object-keys",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#define-properties#object-keys",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "object-keys",
+      "version": "1.1.1",
+      "size": 26544,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/object.assign",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#object.assign",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "object.assign",
+      "version": "4.1.2",
+      "size": 62368,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/object.entries",
+      "breadcrumb": "eslint-config-next#eslint-plugin-react#object.entries",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "object.entries",
+      "version": "1.1.5",
+      "size": 29529,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/object.fromentries",
+      "breadcrumb": "eslint-config-next#eslint-plugin-react#object.fromentries",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "object.fromentries",
+      "version": "2.0.5",
+      "size": 13192,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/once",
+      "breadcrumb": "eslint-config-next#eslint-import-resolver-typescript#glob#once",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "once",
+      "version": "1.4.0",
+      "size": 4046,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/object.values",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#object.values",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "object.values",
+      "version": "1.1.5",
+      "size": 29009,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/onetime",
+      "breadcrumb": "jest#@jest/core#jest-changed-files#execa#onetime",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "onetime",
+      "version": "5.1.2",
+      "size": 6173,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/object.hasown",
+      "breadcrumb": "eslint-config-next#eslint-plugin-react#object.hasown",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "object.hasown",
+      "version": "1.1.0",
+      "size": 13644,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/optionator",
+      "breadcrumb": "eslint-config-next#eslint#optionator",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "optionator",
+      "version": "0.9.1",
+      "size": 50156,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/ora",
+      "breadcrumb": "ora",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "ora",
+      "version": "5.4.1",
+      "size": 23247,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/p-limit",
+      "breadcrumb": "jest#import-local#pkg-dir#find-up#locate-path#p-locate#p-limit",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "p-limit",
+      "version": "2.3.0",
+      "size": 7390,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/p-locate",
+      "breadcrumb": "jest#import-local#pkg-dir#find-up#locate-path#p-locate",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "p-locate",
+      "version": "4.1.0",
+      "size": 7285,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/p-map",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#p-map",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "p-map",
+      "version": "4.0.0",
+      "size": 8687,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/package-json-type",
+      "breadcrumb": "package-json-type",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "package-json-type",
+      "version": "1.0.3",
+      "size": 73643,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/p-try",
+      "breadcrumb": "jest#import-local#pkg-dir#find-up#locate-path#p-locate#p-limit#p-try",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "p-try",
+      "version": "2.2.0",
+      "size": 4371,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/parse-conflict-json",
+      "breadcrumb": "@npmcli/arborist#parse-conflict-json",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "parse-conflict-json",
+      "version": "2.0.2",
+      "size": 6431,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/pacote",
+      "breadcrumb": "@npmcli/arborist#pacote",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "pacote",
+      "version": "13.1.1",
+      "size": 67237,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/parent-module",
+      "breadcrumb": "eslint-config-next#eslint#import-fresh#parent-module",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "parent-module",
+      "version": "1.0.1",
+      "size": 3922,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/parse-json",
+      "breadcrumb": "jest#jest-cli#jest-config#parse-json",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "parse-json",
+      "version": "5.2.0",
+      "size": 5409,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/parse5",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#parse5",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "parse5",
+      "version": "6.0.1",
+      "size": 331125,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/path-exists",
+      "breadcrumb": "jest#import-local#pkg-dir#find-up#path-exists",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "path-exists",
+      "version": "4.0.0",
+      "size": 3919,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/path-is-absolute",
+      "breadcrumb": "eslint-config-next#eslint-import-resolver-typescript#glob#path-is-absolute",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "path-is-absolute",
+      "version": "1.0.1",
+      "size": 3616,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/path-key",
+      "breadcrumb": "eslint-config-next#eslint#cross-spawn#path-key",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "path-key",
+      "version": "3.1.1",
+      "size": 4553,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/path-parse",
+      "breadcrumb": "eslint-config-next#eslint-import-resolver-node#resolve#path-parse",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "path-parse",
+      "version": "1.0.7",
+      "size": 4511,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/picocolors",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#@babel/helper-compilation-targets#browserslist#picocolors",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "picocolors",
+      "version": "1.0.0",
+      "size": 5655,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/picomatch",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-resolve#jest-haste-map#anymatch#picomatch",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "picomatch",
+      "version": "2.3.1",
+      "size": 89952,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/pidtree",
+      "breadcrumb": "lint-staged#pidtree",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "pidtree",
+      "version": "0.5.0",
+      "size": 21998,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/pirates",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@jest/transform#pirates",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "pirates",
+      "version": "4.0.5",
+      "size": 13423,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/pkg-dir",
+      "breadcrumb": "jest#import-local#pkg-dir",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "pkg-dir",
+      "version": "4.2.0",
+      "size": 4750,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/postcss",
+      "breadcrumb": "eslint-config-next#next#postcss",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "postcss",
+      "version": "8.4.5",
+      "size": 185740,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/prelude-ls",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator#levn#type-check#prelude-ls",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "prelude-ls",
+      "version": "1.1.2",
+      "size": 36015,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/path-type",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#dir-glob#path-type",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "path-type",
+      "version": "4.0.0",
+      "size": 5407,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/pretty-format",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#pretty-format",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "pretty-format",
+      "version": "27.5.1",
+      "size": 70072,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/prettier",
+      "breadcrumb": "prettier",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "prettier",
+      "version": "2.6.2",
+      "size": 17650625,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/proc-log",
+      "breadcrumb": "@npmcli/arborist#pacote#npm-registry-fetch#proc-log",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "proc-log",
+      "version": "2.0.1",
+      "size": 5251,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/promise-all-reject-late",
+      "breadcrumb": "@npmcli/arborist#promise-all-reject-late",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "promise-all-reject-late",
+      "version": "1.0.1",
+      "size": 123171,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/promise-call-limit",
+      "breadcrumb": "@npmcli/arborist#promise-call-limit",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "promise-call-limit",
+      "version": "1.0.1",
+      "size": 3157,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/promise-inflight",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#promise-inflight",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "promise-inflight",
+      "version": "1.0.1",
+      "size": 3045,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/promise-retry",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#promise-retry",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "promise-retry",
+      "version": "2.0.1",
+      "size": 15556,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/prompts",
+      "breadcrumb": "jest#jest-cli#prompts",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "prompts",
+      "version": "2.4.2",
+      "size": 186815,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/prop-types",
+      "breadcrumb": "eslint-config-next#eslint-plugin-react#prop-types",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "prop-types",
+      "version": "15.8.1",
+      "size": 94537,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/psl",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#tough-cookie#psl",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "psl",
+      "version": "1.8.0",
+      "size": 433019,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/punycode",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#tough-cookie#punycode",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "punycode",
+      "version": "2.1.1",
+      "size": 32434,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/raw-body",
+      "breadcrumb": "apollo-server-micro#micro#raw-body",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "raw-body",
+      "version": "2.3.2",
+      "size": 22113,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/queue-microtask",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#fast-glob#@nodelib/fs.walk#@nodelib/fs.scandir#run-parallel#queue-microtask",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "queue-microtask",
+      "version": "1.2.3",
+      "size": 8367,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/react",
+      "breadcrumb": "eslint-config-next#next#react",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "react",
+      "version": "18.0.0",
+      "size": 315644,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/react-dom",
+      "breadcrumb": "eslint-config-next#next#react-dom",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "react-dom",
+      "version": "18.0.0",
+      "size": 4377410,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/read-cmd-shim",
+      "breadcrumb": "@npmcli/arborist#bin-links#read-cmd-shim",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "read-cmd-shim",
+      "version": "3.0.0",
+      "size": 5231,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/react-is",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#pretty-format#react-is",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "react-is",
+      "version": "17.0.2",
+      "size": 24767,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/read-package-json",
+      "breadcrumb": "@npmcli/arborist#pacote#read-package-json",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "read-package-json",
+      "version": "5.0.1",
+      "size": 20818,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/read-package-json-fast",
+      "breadcrumb": "@npmcli/arborist#pacote#read-package-json-fast",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "read-package-json-fast",
+      "version": "2.0.3",
+      "size": 8253,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/readable-stream",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#npmlog#are-we-there-yet#readable-stream",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "readable-stream",
+      "version": "3.6.0",
+      "size": 122295,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/readdir-scoped-modules",
+      "breadcrumb": "@npmcli/arborist#readdir-scoped-modules",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "readdir-scoped-modules",
+      "version": "1.1.0",
+      "size": 4927,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/regenerator-runtime",
+      "breadcrumb": "eslint-config-next#eslint-plugin-jsx-a11y#aria-query#@babel/runtime#regenerator-runtime",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "regenerator-runtime",
+      "version": "0.13.9",
+      "size": 27401,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/regexpp",
+      "breadcrumb": "eslint-config-next#eslint#regexpp",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "regexpp",
+      "version": "3.2.0",
+      "size": 302373,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/require-directory",
+      "breadcrumb": "yargs#require-directory",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "require-directory",
+      "version": "2.1.1",
+      "size": 12071,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/regexp.prototype.flags",
+      "breadcrumb": "eslint-config-next#eslint-plugin-react#string.prototype.matchall#regexp.prototype.flags",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "regexp.prototype.flags",
+      "version": "1.4.3",
+      "size": 36699,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/resolve",
+      "breadcrumb": "eslint-config-next#eslint-import-resolver-node#resolve",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "resolve",
+      "version": "1.22.0",
+      "size": 143964,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/resolve-cwd",
+      "breadcrumb": "jest#import-local#resolve-cwd",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "resolve-cwd",
+      "version": "3.0.0",
+      "size": 4984,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/resolve-from",
+      "breadcrumb": "jest#import-local#resolve-cwd#resolve-from",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "resolve-from",
+      "version": "5.0.0",
+      "size": 5824,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/resolve.exports",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-resolve#resolve.exports",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "resolve.exports",
+      "version": "1.1.0",
+      "size": 20266,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/restore-cursor",
+      "breadcrumb": "lint-staged#listr2#log-update#cli-cursor#restore-cursor",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "restore-cursor",
+      "version": "3.1.0",
+      "size": 2817,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/retry",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#async-retry#retry",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "retry",
+      "version": "0.13.1",
+      "size": 18852,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/reusify",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#fast-glob#@nodelib/fs.walk#fastq#reusify",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "reusify",
+      "version": "1.0.4",
+      "size": 9442,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/rfdc",
+      "breadcrumb": "lint-staged#listr2#rfdc",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "rfdc",
+      "version": "1.3.0",
+      "size": 24045,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/rimraf",
+      "breadcrumb": "@npmcli/arborist#bin-links#rimraf",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "rimraf",
+      "version": "3.0.2",
+      "size": 17327,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/run-parallel",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#fast-glob#@nodelib/fs.walk#@nodelib/fs.scandir#run-parallel",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "run-parallel",
+      "version": "1.2.0",
+      "size": 6563,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/rxjs",
+      "breadcrumb": "lint-staged#listr2#rxjs",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "rxjs",
+      "version": "7.5.5",
+      "size": 4479911,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/safe-buffer",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#sha.js#safe-buffer",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "safe-buffer",
+      "version": "5.2.1",
+      "size": 32101,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/safer-buffer",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#minipass-fetch#encoding#iconv-lite#safer-buffer",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "safer-buffer",
+      "version": "2.1.2",
+      "size": 42299,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/saxes",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#saxes",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "saxes",
+      "version": "5.0.1",
+      "size": 164263,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/scheduler",
+      "breadcrumb": "eslint-config-next#next#react-dom#scheduler",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "scheduler",
+      "version": "0.21.0",
+      "size": 93383,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/semver",
+      "breadcrumb": "@npmcli/arborist#pacote#npm-pick-manifest#npm-package-arg#validate-npm-package-name#builtins#semver",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "semver",
+      "version": "7.3.7",
+      "size": 87418,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/set-blocking",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#npmlog#set-blocking",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "set-blocking",
+      "version": "2.0.0",
+      "size": 4224,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/setprototypeof",
+      "breadcrumb": "apollo-server-micro#micro#raw-body#http-errors#setprototypeof",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "setprototypeof",
+      "version": "1.0.3",
+      "size": 2042,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/sha.js",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#sha.js",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "sha.js",
+      "version": "2.4.11",
+      "size": 31084,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/shebang-command",
+      "breadcrumb": "eslint-config-next#eslint#cross-spawn#shebang-command",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "shebang-command",
+      "version": "2.0.0",
+      "size": 2556,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/shebang-regex",
+      "breadcrumb": "eslint-config-next#eslint#cross-spawn#shebang-command#shebang-regex",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "shebang-regex",
+      "version": "3.0.0",
+      "size": 2828,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/side-channel",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#internal-slot#side-channel",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "side-channel",
+      "version": "1.0.4",
+      "size": 14565,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/signal-exit",
+      "breadcrumb": "jest#@jest/core#jest-changed-files#execa#signal-exit",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "signal-exit",
+      "version": "3.0.7",
+      "size": 9958,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/sisteransi",
+      "breadcrumb": "jest#jest-cli#prompts#sisteransi",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "sisteransi",
+      "version": "1.0.5",
+      "size": 6791,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/slice-ansi",
+      "breadcrumb": "lint-staged#cli-truncate#slice-ansi",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "slice-ansi",
+      "version": "5.0.0",
+      "size": 6412,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/slash",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#slash",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "slash",
+      "version": "3.0.0",
+      "size": 3507,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/socks",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#socks-proxy-agent#socks",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "socks",
+      "version": "2.6.2",
+      "size": 151784,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/socks-proxy-agent",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#socks-proxy-agent",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "socks-proxy-agent",
+      "version": "6.2.0",
+      "size": 27409,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/smart-buffer",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#socks-proxy-agent#socks#smart-buffer",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "smart-buffer",
+      "version": "4.2.0",
+      "size": 138027,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/source-map",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#source-map",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "source-map",
+      "version": "0.6.1",
+      "size": 805224,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/source-map-js",
+      "breadcrumb": "eslint-config-next#next#postcss#source-map-js",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "source-map-js",
+      "version": "1.0.2",
+      "size": 147831,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/source-map-support",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-runner#source-map-support",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "source-map-support",
+      "version": "0.5.21",
+      "size": 85177,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/spdx-correct",
+      "breadcrumb": "@npmcli/arborist#pacote#read-package-json#normalize-package-data#validate-npm-package-license#spdx-correct",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "spdx-correct",
+      "version": "3.1.1",
+      "size": 22402,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/spdx-exceptions",
+      "breadcrumb": "@npmcli/arborist#pacote#read-package-json#normalize-package-data#validate-npm-package-license#spdx-correct#spdx-expression-parse#spdx-exceptions",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "spdx-exceptions",
+      "version": "2.3.0",
+      "size": 2660,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/spdx-expression-parse",
+      "breadcrumb": "@npmcli/arborist#pacote#read-package-json#normalize-package-data#validate-npm-package-license#spdx-correct#spdx-expression-parse",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "spdx-expression-parse",
+      "version": "3.0.1",
+      "size": 11850,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/spdx-license-ids",
+      "breadcrumb": "@npmcli/arborist#pacote#read-package-json#normalize-package-data#validate-npm-package-license#spdx-correct#spdx-license-ids",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "spdx-license-ids",
+      "version": "3.0.11",
+      "size": 9736,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/sprintf-js",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@istanbuljs/load-nyc-config#js-yaml#argparse#sprintf-js",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "sprintf-js",
+      "version": "1.0.3",
+      "size": 34784,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/ssri",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#ssri",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "ssri",
+      "version": "9.0.0",
+      "size": 36854,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/stack-utils",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#stack-utils",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "stack-utils",
+      "version": "2.0.5",
+      "size": 14432,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/string-argv",
+      "breadcrumb": "lint-staged#string-argv",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "string-argv",
+      "version": "0.3.1",
+      "size": 6123,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/statuses",
+      "breadcrumb": "apollo-server-micro#micro#raw-body#http-errors#statuses",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "statuses",
+      "version": "1.5.0",
+      "size": 11034,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/string-length",
+      "breadcrumb": "jest#@jest/core#jest-watcher#string-length",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "string-length",
+      "version": "4.0.2",
+      "size": 4052,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/string-width",
+      "breadcrumb": "yargs#cliui#string-width",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "string-width",
+      "version": "4.2.3",
+      "size": 5161,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/string.prototype.matchall",
+      "breadcrumb": "eslint-config-next#eslint-plugin-react#string.prototype.matchall",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "string.prototype.matchall",
+      "version": "4.0.7",
+      "size": 34693,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/string.prototype.trimend",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#string.prototype.trimend",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "string.prototype.trimend",
+      "version": "1.0.4",
+      "size": 16709,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/string.prototype.trimstart",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#string.prototype.trimstart",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "string.prototype.trimstart",
+      "version": "1.0.4",
+      "size": 16904,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/string_decoder",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#npmlog#are-we-there-yet#readable-stream#string_decoder",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "string_decoder",
+      "version": "1.3.0",
+      "size": 14427,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/strip-ansi",
+      "breadcrumb": "yargs#cliui#strip-ansi",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "size": 4029,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/strip-bom",
+      "breadcrumb": "eslint-config-next#eslint-import-resolver-typescript#tsconfig-paths#strip-bom",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "strip-bom",
+      "version": "3.0.0",
+      "size": 3004,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/strip-final-newline",
+      "breadcrumb": "jest#@jest/core#jest-changed-files#execa#strip-final-newline",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "strip-final-newline",
+      "version": "2.0.0",
+      "size": 3046,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/strip-json-comments",
+      "breadcrumb": "eslint-config-next#eslint#strip-json-comments",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "strip-json-comments",
+      "version": "3.1.1",
+      "size": 6959,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/styled-jsx",
+      "breadcrumb": "eslint-config-next#next#styled-jsx",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "styled-jsx",
+      "version": "5.0.1",
+      "size": 867204,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/supports-color",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#chalk#supports-color",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "supports-color",
+      "version": "7.2.0",
+      "size": 7035,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/supports-hyperlinks",
+      "breadcrumb": "jest#@jest/core#@jest/reporters#terminal-link#supports-hyperlinks",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "supports-hyperlinks",
+      "version": "2.2.0",
+      "size": 6705,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/symbol-tree",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#symbol-tree",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "symbol-tree",
+      "version": "3.2.4",
+      "size": 57073,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/tar",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#tar",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "tar",
+      "version": "6.1.11",
+      "size": 160662,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/terminal-link",
+      "breadcrumb": "jest#@jest/core#@jest/reporters#terminal-link",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "terminal-link",
+      "version": "2.1.1",
+      "size": 6520,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/text-table",
+      "breadcrumb": "eslint-config-next#eslint#text-table",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "text-table",
+      "version": "0.2.0",
+      "size": 11014,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/supports-preserve-symlinks-flag",
+      "breadcrumb": "eslint-config-next#eslint-import-resolver-node#resolve#supports-preserve-symlinks-flag",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "supports-preserve-symlinks-flag",
+      "version": "1.0.0",
+      "size": 9178,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/test-exclude",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#test-exclude",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "test-exclude",
+      "version": "6.0.0",
+      "size": 23612,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/through",
+      "breadcrumb": "lint-staged#listr2#through",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "through",
+      "version": "2.3.8",
+      "size": 12533,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/throat",
+      "breadcrumb": "jest#@jest/core#jest-changed-files#throat",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "throat",
+      "version": "6.0.1",
+      "size": 9160,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/tmpl",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-resolve#jest-haste-map#walker#makeerror#tmpl",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "tmpl",
+      "version": "1.0.5",
+      "size": 2774,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/to-regex-range",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#fast-glob#micromatch#braces#fill-range#to-regex-range",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "to-regex-range",
+      "version": "5.0.1",
+      "size": 22939,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/tough-cookie",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#tough-cookie",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "tough-cookie",
+      "version": "4.0.0",
+      "size": 98591,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/tmp",
+      "breadcrumb": "tmp",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "tmp",
+      "version": "0.2.1",
+      "size": 52938,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/to-fast-properties",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-preset-jest#babel-plugin-jest-hoist#@babel/types#to-fast-properties",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "to-fast-properties",
+      "version": "2.0.0",
+      "size": 3496,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/tr46",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#data-urls#whatwg-url#tr46",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "tr46",
+      "version": "2.1.0",
+      "size": 210389,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/treeverse",
+      "breadcrumb": "@npmcli/arborist#treeverse",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "treeverse",
+      "version": "2.0.0",
+      "size": 12959,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/tsconfig-paths",
+      "breadcrumb": "eslint-config-next#eslint-import-resolver-typescript#tsconfig-paths",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "tsconfig-paths",
+      "version": "3.14.1",
+      "size": 203206,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/tslib",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#@graphql-tools/mock#tslib",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "tslib",
+      "version": "2.3.1",
+      "size": 39088,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/tsutils",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#tsutils",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "tsutils",
+      "version": "3.21.0",
+      "size": 382326,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/type-check",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator#levn#type-check",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "type-check",
+      "version": "0.3.2",
+      "size": 20856,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/type-detect",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#@jest/fake-timers#@sinonjs/fake-timers#@sinonjs/commons#type-detect",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "type-detect",
+      "version": "4.0.8",
+      "size": 42110,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/type-fest",
+      "breadcrumb": "eslint-config-next#eslint#globals#type-fest",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "type-fest",
+      "version": "0.20.2",
+      "size": 110590,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/type-is",
+      "breadcrumb": "apollo-server-micro#type-is",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "type-is",
+      "version": "1.6.18",
+      "size": 18497,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/typescript",
+      "breadcrumb": "eslint-config-next#typescript",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "typescript",
+      "version": "4.6.3",
+      "size": 64715549,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/unbox-primitive",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#unbox-primitive",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "unbox-primitive",
+      "version": "1.0.2",
+      "size": 14851,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/unique-filename",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#unique-filename",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "unique-filename",
+      "version": "1.1.1",
+      "size": 41421,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/typedarray-to-buffer",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@jest/transform#write-file-atomic#typedarray-to-buffer",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "typedarray-to-buffer",
+      "version": "3.1.5",
+      "size": 8835,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/unique-slug",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#unique-filename#unique-slug",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "unique-slug",
+      "version": "2.0.2",
+      "size": 2679,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/universalify",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#tough-cookie#universalify",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "universalify",
+      "version": "0.1.2",
+      "size": 4705,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/unpipe",
+      "breadcrumb": "apollo-server-micro#micro#raw-body#unpipe",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "unpipe",
+      "version": "1.0.0",
+      "size": 4311,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/util-deprecate",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#npmlog#are-we-there-yet#readable-stream#util-deprecate",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "util-deprecate",
+      "version": "1.0.2",
+      "size": 5481,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/uuid",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#uuid",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "uuid",
+      "version": "8.3.2",
+      "size": 116098,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/uri-js",
+      "breadcrumb": "eslint-config-next#eslint#ajv#uri-js",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "uri-js",
+      "version": "4.4.1",
+      "size": 469879,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/v8-compile-cache",
+      "breadcrumb": "eslint-config-next#eslint#v8-compile-cache",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "v8-compile-cache",
+      "version": "2.3.0",
+      "size": 16807,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/validate-npm-package-name",
+      "breadcrumb": "@npmcli/arborist#pacote#npm-pick-manifest#npm-package-arg#validate-npm-package-name",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "validate-npm-package-name",
+      "version": "4.0.0",
+      "size": 7927,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/v8-to-istanbul",
+      "breadcrumb": "jest#@jest/core#@jest/reporters#v8-to-istanbul",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "v8-to-istanbul",
+      "version": "8.1.1",
+      "size": 43941,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/validate-npm-package-license",
+      "breadcrumb": "@npmcli/arborist#pacote#read-package-json#normalize-package-data#validate-npm-package-license",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "validate-npm-package-license",
+      "version": "3.0.4",
+      "size": 16597,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/w3c-hr-time",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#w3c-hr-time",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "w3c-hr-time",
+      "version": "1.0.2",
+      "size": 16806,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/w3c-xmlserializer",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#w3c-xmlserializer",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "w3c-xmlserializer",
+      "version": "2.0.0",
+      "size": 18036,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/walk-up-path",
+      "breadcrumb": "@npmcli/arborist#walk-up-path",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "walk-up-path",
+      "version": "1.0.0",
+      "size": 2350,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/value-or-promise",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#@graphql-tools/schema#value-or-promise",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "value-or-promise",
+      "version": "1.0.11",
+      "size": 28458,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/walker",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-resolve#jest-haste-map#walker",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "walker",
+      "version": "1.0.8",
+      "size": 5799,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/webidl-conversions",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#webidl-conversions",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "webidl-conversions",
+      "version": "6.1.0",
+      "size": 25919,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/wcwidth",
+      "breadcrumb": "ora#wcwidth",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "wcwidth",
+      "version": "1.0.1",
+      "size": 14241,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/whatwg-encoding",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#html-encoding-sniffer#whatwg-encoding",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "whatwg-encoding",
+      "version": "1.0.5",
+      "size": 12341,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/whatwg-url",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#data-urls#whatwg-url",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "whatwg-url",
+      "version": "8.7.0",
+      "size": 90738,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/which",
+      "breadcrumb": "eslint-config-next#eslint#cross-spawn#which",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "which",
+      "version": "2.0.2",
+      "size": 9975,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/which-boxed-primitive",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#array-includes#es-abstract#unbox-primitive#which-boxed-primitive",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "which-boxed-primitive",
+      "version": "1.0.2",
+      "size": 15028,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/wide-align",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#npmlog#gauge#wide-align",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "wide-align",
+      "version": "1.1.5",
+      "size": 4467,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/word-wrap",
+      "breadcrumb": "eslint-config-next#eslint#optionator#word-wrap",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "word-wrap",
+      "version": "1.2.3",
+      "size": 10584,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/wrap-ansi",
+      "breadcrumb": "yargs#cliui#wrap-ansi",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "size": 10648,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/wrappy",
+      "breadcrumb": "@npmcli/arborist#readdir-scoped-modules#dezalgo#wrappy",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "wrappy",
+      "version": "1.0.2",
+      "size": 2961,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/write-file-atomic",
+      "breadcrumb": "@npmcli/arborist#bin-links#write-file-atomic",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "write-file-atomic",
+      "version": "4.0.1",
+      "size": 11920,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/whatwg-mimetype",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#data-urls#whatwg-mimetype",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "whatwg-mimetype",
+      "version": "2.3.0",
+      "size": 16182,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/ws",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#ws",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "ws",
+      "version": "7.5.7",
+      "size": 121534,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/xml-name-validator",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#xml-name-validator",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "xml-name-validator",
+      "version": "3.0.0",
+      "size": 22952,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/xmlchars",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#saxes#xmlchars",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "xmlchars",
+      "version": "2.2.0",
+      "size": 58957,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/xss",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#@apollographql/graphql-playground-html#xss",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "xss",
+      "version": "1.0.11",
+      "size": 143343,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/y18n",
+      "breadcrumb": "yargs#y18n",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "y18n",
+      "version": "5.0.8",
+      "size": 23435,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/yallist",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#minipass#yallist",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "yallist",
+      "version": "4.0.0",
+      "size": 14752,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/yaml",
+      "breadcrumb": "lint-staged#yaml",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "yaml",
+      "version": "1.10.2",
+      "size": 448149,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/yargs",
+      "breadcrumb": "yargs",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "yargs",
+      "version": "17.4.1",
+      "size": 284791,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/yargs-parser",
+      "breadcrumb": "yargs#yargs-parser",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "yargs-parser",
+      "version": "21.0.1",
+      "size": 126343,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@ampproject/remapping",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#@ampproject/remapping",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@ampproject/remapping",
+      "version": "2.1.2",
+      "size": 65167,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@apollo/protobufjs",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@apollo/protobufjs",
+      "version": "1.2.2",
+      "size": 3159388,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/code-frame",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/code-frame",
+      "version": "7.16.7",
+      "size": 6957,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@apollographql/graphql-playground-html",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#@apollographql/graphql-playground-html",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@apollographql/graphql-playground-html",
+      "version": "1.6.29",
+      "size": 28444,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@apollographql/apollo-tools",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#@apollographql/apollo-tools",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@apollographql/apollo-tools",
+      "version": "0.5.3",
+      "size": 167972,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/core",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/core",
+      "version": "7.17.9",
+      "size": 267509,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/generator",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-snapshot#@babel/generator",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/generator",
+      "version": "7.17.9",
+      "size": 120106,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/compat-data",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#@babel/helper-compilation-targets#@babel/compat-data",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/compat-data",
+      "version": "7.17.7",
+      "size": 50547,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/helper-compilation-targets",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#@babel/helper-compilation-targets",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/helper-compilation-targets",
+      "version": "7.17.7",
+      "size": 16895,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/helper-environment-visitor",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#@babel/helper-module-transforms#@babel/helper-environment-visitor",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/helper-environment-visitor",
+      "version": "7.16.7",
+      "size": 3049,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/helper-hoist-variables",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-snapshot#@babel/traverse#@babel/helper-hoist-variables",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/helper-hoist-variables",
+      "version": "7.16.7",
+      "size": 3439,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/helper-module-imports",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#@babel/helper-module-transforms#@babel/helper-module-imports",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/helper-module-imports",
+      "version": "7.16.7",
+      "size": 16295,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/helper-function-name",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-snapshot#@babel/traverse#@babel/helper-function-name",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/helper-function-name",
+      "version": "7.17.9",
+      "size": 6664,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/helper-module-transforms",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#@babel/helper-module-transforms",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/helper-module-transforms",
+      "version": "7.17.7",
+      "size": 41316,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/helper-plugin-utils",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@babel/helper-plugin-utils",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/helper-plugin-utils",
+      "version": "7.16.7",
+      "size": 4406,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/helper-simple-access",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#@babel/helper-module-transforms#@babel/helper-simple-access",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/helper-simple-access",
+      "version": "7.17.7",
+      "size": 5157,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/helper-split-export-declaration",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#@babel/helper-module-transforms#@babel/helper-split-export-declaration",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/helper-split-export-declaration",
+      "version": "7.16.7",
+      "size": 4315,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/helper-validator-identifier",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#@babel/helper-module-transforms#@babel/helper-validator-identifier",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/helper-validator-identifier",
+      "version": "7.16.7",
+      "size": 19045,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/helper-validator-option",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#@babel/helper-compilation-targets#@babel/helper-validator-option",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/helper-validator-option",
+      "version": "7.16.7",
+      "size": 4573,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/highlight",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/highlight",
+      "version": "7.17.9",
+      "size": 4885,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/parser",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#istanbul-lib-instrument#@babel/parser",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/parser",
+      "version": "7.17.9",
+      "size": 1762051,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/plugin-syntax-async-generators",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-preset-jest#babel-preset-current-node-syntax#@babel/plugin-syntax-async-generators",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/plugin-syntax-async-generators",
+      "version": "7.8.4",
+      "size": 2524,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/plugin-syntax-bigint",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-preset-jest#babel-preset-current-node-syntax#@babel/plugin-syntax-bigint",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/plugin-syntax-bigint",
+      "version": "7.8.3",
+      "size": 2415,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/plugin-syntax-class-properties",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-preset-jest#babel-preset-current-node-syntax#@babel/plugin-syntax-class-properties",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/plugin-syntax-class-properties",
+      "version": "7.12.13",
+      "size": 2682,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/plugin-syntax-import-meta",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-preset-jest#babel-preset-current-node-syntax#@babel/plugin-syntax-import-meta",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/plugin-syntax-import-meta",
+      "version": "7.10.4",
+      "size": 2559,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/helpers",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#@babel/helpers",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/helpers",
+      "version": "7.17.9",
+      "size": 109710,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/plugin-syntax-json-strings",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-preset-jest#babel-preset-current-node-syntax#@babel/plugin-syntax-json-strings",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/plugin-syntax-json-strings",
+      "version": "7.8.3",
+      "size": 2578,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/plugin-syntax-logical-assignment-operators",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-preset-jest#babel-preset-current-node-syntax#@babel/plugin-syntax-logical-assignment-operators",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/plugin-syntax-logical-assignment-operators",
+      "version": "7.10.4",
+      "size": 2744,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/plugin-syntax-nullish-coalescing-operator",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-preset-jest#babel-preset-current-node-syntax#@babel/plugin-syntax-nullish-coalescing-operator",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/plugin-syntax-nullish-coalescing-operator",
+      "version": "7.8.3",
+      "size": 2634,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/plugin-syntax-object-rest-spread",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-preset-jest#babel-preset-current-node-syntax#@babel/plugin-syntax-object-rest-spread",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/plugin-syntax-object-rest-spread",
+      "version": "7.8.3",
+      "size": 2527,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/plugin-syntax-numeric-separator",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-preset-jest#babel-preset-current-node-syntax#@babel/plugin-syntax-numeric-separator",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/plugin-syntax-numeric-separator",
+      "version": "7.10.4",
+      "size": 2751,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/plugin-syntax-optional-catch-binding",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-preset-jest#babel-preset-current-node-syntax#@babel/plugin-syntax-optional-catch-binding",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/plugin-syntax-optional-catch-binding",
+      "version": "7.8.3",
+      "size": 2573,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/plugin-syntax-optional-chaining",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-preset-jest#babel-preset-current-node-syntax#@babel/plugin-syntax-optional-chaining",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/plugin-syntax-optional-chaining",
+      "version": "7.8.3",
+      "size": 2521,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/plugin-syntax-top-level-await",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-preset-jest#babel-preset-current-node-syntax#@babel/plugin-syntax-top-level-await",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/plugin-syntax-top-level-await",
+      "version": "7.14.5",
+      "size": 2738,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/plugin-syntax-typescript",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-snapshot#@babel/plugin-syntax-typescript",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/plugin-syntax-typescript",
+      "version": "7.16.7",
+      "size": 3912,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/runtime",
+      "breadcrumb": "eslint-config-next#eslint-plugin-jsx-a11y#aria-query#@babel/runtime",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/runtime",
+      "version": "7.17.9",
+      "size": 172598,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/template",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-preset-jest#babel-plugin-jest-hoist#@babel/template",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/template",
+      "version": "7.16.7",
+      "size": 21378,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/traverse",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-snapshot#@babel/traverse",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/traverse",
+      "version": "7.17.9",
+      "size": 154380,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/types",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-preset-jest#babel-plugin-jest-hoist#@babel/types",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/types",
+      "version": "7.17.0",
+      "size": 1032242,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/runtime-corejs3",
+      "breadcrumb": "eslint-config-next#eslint-plugin-jsx-a11y#aria-query#@babel/runtime-corejs3",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@babel/runtime-corejs3",
+      "version": "7.17.9",
+      "size": 238211,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@eslint/eslintrc",
+      "breadcrumb": "eslint-config-next#eslint#@eslint/eslintrc",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@eslint/eslintrc",
+      "version": "1.2.2",
+      "size": 650597,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@gar/promisify",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#@npmcli/fs#@gar/promisify",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@gar/promisify",
+      "version": "1.1.3",
+      "size": 4197,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@bcoe/v8-coverage",
+      "breadcrumb": "jest#@jest/core#@jest/reporters#@bcoe/v8-coverage",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@bcoe/v8-coverage",
+      "version": "0.2.3",
+      "size": 276877,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@graphql-tools/mock",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#@graphql-tools/mock",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@graphql-tools/mock",
+      "version": "8.6.8",
+      "size": 88744,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@graphql-tools/schema",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#@graphql-tools/schema",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@graphql-tools/schema",
+      "version": "8.3.10",
+      "size": 59426,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@graphql-tools/utils",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#@graphql-tools/mock#@graphql-tools/utils",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@graphql-tools/utils",
+      "version": "8.6.9",
+      "size": 380230,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@hapi/accept",
+      "breadcrumb": "apollo-server-micro#@hapi/accept",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@hapi/accept",
+      "version": "5.0.2",
+      "size": 23418,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@graphql-tools/merge",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#@graphql-tools/schema#@graphql-tools/merge",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@graphql-tools/merge",
+      "version": "8.2.10",
+      "size": 84304,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@hapi/hoek",
+      "breadcrumb": "apollo-server-micro#@hapi/accept#@hapi/hoek",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@hapi/hoek",
+      "version": "9.2.1",
+      "size": 51151,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@hapi/boom",
+      "breadcrumb": "apollo-server-micro#@hapi/accept#@hapi/boom",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@hapi/boom",
+      "version": "9.1.4",
+      "size": 28311,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@humanwhocodes/config-array",
+      "breadcrumb": "eslint-config-next#eslint#@humanwhocodes/config-array",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@humanwhocodes/config-array",
+      "version": "0.9.5",
+      "size": 45535,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@humanwhocodes/object-schema",
+      "breadcrumb": "eslint-config-next#eslint#@humanwhocodes/config-array#@humanwhocodes/object-schema",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@humanwhocodes/object-schema",
+      "version": "1.2.1",
+      "size": 49395,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@isaacs/string-locale-compare",
+      "breadcrumb": "@npmcli/arborist#@isaacs/string-locale-compare",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@isaacs/string-locale-compare",
+      "version": "1.1.0",
+      "size": 3162,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@istanbuljs/load-nyc-config",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@istanbuljs/load-nyc-config",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@istanbuljs/load-nyc-config",
+      "version": "1.1.0",
+      "size": 10873,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@jest/console",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-runner#@jest/console",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@jest/console",
+      "version": "27.5.1",
+      "size": 21647,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@istanbuljs/schema",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@istanbuljs/schema",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@istanbuljs/schema",
+      "version": "0.1.3",
+      "size": 17161,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@jest/core",
+      "breadcrumb": "jest#@jest/core",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@jest/core",
+      "version": "27.5.1",
+      "size": 174089,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@jest/environment",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#@jest/environment",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@jest/environment",
+      "version": "27.5.1",
+      "size": 12412,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@jest/fake-timers",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#@jest/fake-timers",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@jest/fake-timers",
+      "version": "27.5.1",
+      "size": 26476,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@jest/reporters",
+      "breadcrumb": "jest#@jest/core#@jest/reporters",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@jest/reporters",
+      "version": "27.5.1",
+      "size": 103180,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@jest/globals",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-runtime#@jest/globals",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@jest/globals",
+      "version": "27.5.1",
+      "size": 3564,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@jest/source-map",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-jasmine2#@jest/source-map",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@jest/source-map",
+      "version": "27.5.1",
+      "size": 5654,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@jest/test-result",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#@jest/test-result",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@jest/test-result",
+      "version": "27.5.1",
+      "size": 17107,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@jest/test-sequencer",
+      "breadcrumb": "jest#jest-cli#jest-config#@jest/test-sequencer",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@jest/test-sequencer",
+      "version": "27.5.1",
+      "size": 10483,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@jest/transform",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@jest/transform",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@jest/transform",
+      "version": "27.5.1",
+      "size": 51520,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@josephg/resolvable",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#@josephg/resolvable",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@josephg/resolvable",
+      "version": "1.0.1",
+      "size": 3210,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@jest/types",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@jest/types",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@jest/types",
+      "version": "27.5.1",
+      "size": 27586,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@next/eslint-plugin-next",
+      "breadcrumb": "eslint-config-next#@next/eslint-plugin-next",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@next/eslint-plugin-next",
+      "version": "12.1.5",
+      "size": 44877,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@next/env",
+      "breadcrumb": "eslint-config-next#next#@next/env",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@next/env",
+      "version": "12.1.5",
+      "size": 7167,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@next/swc-darwin-x64",
+      "breadcrumb": "eslint-config-next#next#@next/swc-darwin-x64",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@next/swc-darwin-x64",
+      "version": "12.1.5",
+      "size": 37864017,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@nodelib/fs.stat",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#fast-glob#@nodelib/fs.stat",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@nodelib/fs.stat",
+      "version": "2.0.5",
+      "size": 11845,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@nodelib/fs.scandir",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#fast-glob#@nodelib/fs.walk#@nodelib/fs.scandir",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@nodelib/fs.scandir",
+      "version": "2.1.5",
+      "size": 22155,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@nodelib/fs.walk",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#fast-glob#@nodelib/fs.walk",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@nodelib/fs.walk",
+      "version": "1.2.8",
+      "size": 26377,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@jridgewell/resolve-uri",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#@ampproject/remapping#@jridgewell/trace-mapping#@jridgewell/resolve-uri",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@jridgewell/resolve-uri",
+      "version": "3.0.6",
+      "size": 46667,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@jridgewell/sourcemap-codec",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#@ampproject/remapping#@jridgewell/trace-mapping#@jridgewell/sourcemap-codec",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@jridgewell/sourcemap-codec",
+      "version": "1.4.11",
+      "size": 28905,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@npmcli/arborist",
+      "breadcrumb": "@npmcli/arborist",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@npmcli/arborist",
+      "version": "5.1.0",
+      "size": 413752,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@jridgewell/trace-mapping",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#@ampproject/remapping#@jridgewell/trace-mapping",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@jridgewell/trace-mapping",
+      "version": "0.3.9",
+      "size": 92278,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@npmcli/fs",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#@npmcli/fs",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@npmcli/fs",
+      "version": "2.1.0",
+      "size": 45320,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@npmcli/git",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/git",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@npmcli/git",
+      "version": "3.0.1",
+      "size": 21766,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@npmcli/map-workspaces",
+      "breadcrumb": "@npmcli/arborist#@npmcli/map-workspaces",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@npmcli/map-workspaces",
+      "version": "2.0.3",
+      "size": 9739,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@npmcli/metavuln-calculator",
+      "breadcrumb": "@npmcli/arborist#@npmcli/metavuln-calculator",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@npmcli/metavuln-calculator",
+      "version": "3.1.0",
+      "size": 30371,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@npmcli/move-file",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#@npmcli/move-file",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@npmcli/move-file",
+      "version": "2.0.0",
+      "size": 8564,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@npmcli/name-from-folder",
+      "breadcrumb": "@npmcli/arborist#@npmcli/name-from-folder",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@npmcli/name-from-folder",
+      "version": "1.0.1",
+      "size": 1957,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@npmcli/installed-package-contents",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/installed-package-contents",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@npmcli/installed-package-contents",
+      "version": "1.0.7",
+      "size": 12688,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@npmcli/node-gyp",
+      "breadcrumb": "@npmcli/arborist#@npmcli/node-gyp",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@npmcli/node-gyp",
+      "version": "2.0.0",
+      "size": 1902,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@npmcli/package-json",
+      "breadcrumb": "@npmcli/arborist#@npmcli/package-json",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@npmcli/package-json",
+      "version": "2.0.0",
+      "size": 12414,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@npmcli/promise-spawn",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/promise-spawn",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@npmcli/promise-spawn",
+      "version": "3.0.0",
+      "size": 5997,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@npmcli/run-script",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@npmcli/run-script",
+      "version": "3.0.2",
+      "size": 16898,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@protobufjs/aspromise",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/aspromise",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@protobufjs/aspromise",
+      "version": "1.1.2",
+      "size": 9055,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@protobufjs/codegen",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/codegen",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@protobufjs/codegen",
+      "version": "2.0.4",
+      "size": 9136,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@protobufjs/base64",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/base64",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@protobufjs/base64",
+      "version": "1.1.2",
+      "size": 9224,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@protobufjs/eventemitter",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/eventemitter",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@protobufjs/eventemitter",
+      "version": "1.1.0",
+      "size": 7752,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@protobufjs/float",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/float",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@protobufjs/float",
+      "version": "1.0.2",
+      "size": 26968,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@protobufjs/fetch",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/fetch",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@protobufjs/fetch",
+      "version": "1.1.0",
+      "size": 8762,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@protobufjs/inquire",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/inquire",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@protobufjs/inquire",
+      "version": "1.1.0",
+      "size": 4287,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@protobufjs/path",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/path",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@protobufjs/path",
+      "version": "1.1.2",
+      "size": 7770,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@protobufjs/pool",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/pool",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@protobufjs/pool",
+      "version": "1.1.0",
+      "size": 6249,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@sinonjs/commons",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#@jest/fake-timers#@sinonjs/fake-timers#@sinonjs/commons",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@sinonjs/commons",
+      "version": "1.8.3",
+      "size": 38021,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@protobufjs/utf8",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/utf8",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@protobufjs/utf8",
+      "version": "1.1.0",
+      "size": 23500,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@rushstack/eslint-patch",
+      "breadcrumb": "eslint-config-next#@rushstack/eslint-patch",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@rushstack/eslint-patch",
+      "version": "1.0.8",
+      "size": 29884,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@sinonjs/fake-timers",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#@jest/fake-timers#@sinonjs/fake-timers",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@sinonjs/fake-timers",
+      "version": "8.1.0",
+      "size": 89082,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@tootallnate/once",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#http-proxy-agent#@tootallnate/once",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@tootallnate/once",
+      "version": "2.0.0",
+      "size": 16332,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/babel__generator",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@types/babel__core#@types/babel__generator",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/babel__generator",
+      "version": "7.6.4",
+      "size": 11663,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/babel__core",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@types/babel__core",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/babel__core",
+      "version": "7.1.19",
+      "size": 32265,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/babel__template",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@types/babel__core#@types/babel__template",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/babel__template",
+      "version": "7.4.1",
+      "size": 6935,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/babel__traverse",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-preset-jest#babel-plugin-jest-hoist#@types/babel__traverse",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/babel__traverse",
+      "version": "7.17.0",
+      "size": 122629,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/debug",
+      "breadcrumb": "@types/debug",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/debug",
+      "version": "4.1.7",
+      "size": 7221,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/graceful-fs",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-resolve#jest-haste-map#@types/graceful-fs",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/graceful-fs",
+      "version": "4.1.5",
+      "size": 3511,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/istanbul-lib-coverage",
+      "breadcrumb": "jest#@jest/core#@jest/reporters#v8-to-istanbul#@types/istanbul-lib-coverage",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/istanbul-lib-coverage",
+      "version": "2.0.4",
+      "size": 5757,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/istanbul-reports",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@jest/types#@types/istanbul-reports",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/istanbul-reports",
+      "version": "3.0.1",
+      "size": 7415,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/jest",
+      "breadcrumb": "@types/jest",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/jest",
+      "version": "27.4.1",
+      "size": 71493,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/json-schema",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/utils#@types/json-schema",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/json-schema",
+      "version": "7.0.11",
+      "size": 32236,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/istanbul-lib-report",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@jest/types#@types/istanbul-reports#@types/istanbul-lib-report",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/istanbul-lib-report",
+      "version": "3.0.0",
+      "size": 8226,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/long",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@types/long",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/long",
+      "version": "4.0.1",
+      "size": 13189,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/json5",
+      "breadcrumb": "eslint-config-next#eslint-import-resolver-typescript#tsconfig-paths#@types/json5",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/json5",
+      "version": "0.0.29",
+      "size": 2998,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/micro",
+      "breadcrumb": "@types/micro-cors#@types/micro",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/micro",
+      "version": "7.3.7",
+      "size": 5561,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/micro-cors",
+      "breadcrumb": "@types/micro-cors",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/micro-cors",
+      "version": "0.1.2",
+      "size": 4365,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/ms",
+      "breadcrumb": "@types/debug#@types/ms",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/ms",
+      "version": "0.7.31",
+      "size": 2878,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/node",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#@types/node",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/node",
+      "version": "17.0.27",
+      "size": 1681348,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/prop-types",
+      "breadcrumb": "@types/react-dom#@types/react#@types/prop-types",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/prop-types",
+      "version": "15.7.5",
+      "size": 6545,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/prettier",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-snapshot#@types/prettier",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/prettier",
+      "version": "2.6.0",
+      "size": 42984,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/react",
+      "breadcrumb": "@types/react-dom#@types/react",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/react",
+      "version": "18.0.6",
+      "size": 174767,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/scheduler",
+      "breadcrumb": "@types/react-dom#@types/react#@types/scheduler",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/scheduler",
+      "version": "0.16.2",
+      "size": 8344,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/react-dom",
+      "breadcrumb": "@types/react-dom",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/react-dom",
+      "version": "18.0.0",
+      "size": 24977,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/semver",
+      "breadcrumb": "@types/semver",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/semver",
+      "version": "7.3.9",
+      "size": 23405,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/tmp",
+      "breadcrumb": "@types/tmp",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/tmp",
+      "version": "0.2.3",
+      "size": 10902,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/stack-utils",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@types/stack-utils",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/stack-utils",
+      "version": "2.0.1",
+      "size": 6968,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/yargs",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@jest/types#@types/yargs",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/yargs",
+      "version": "16.0.4",
+      "size": 53088,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@types/yargs-parser",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@jest/types#@types/yargs#@types/yargs-parser",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/yargs-parser",
+      "version": "21.0.0",
+      "size": 8928,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@typescript-eslint/eslint-plugin",
+      "breadcrumb": "@typescript-eslint/eslint-plugin",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@typescript-eslint/eslint-plugin",
+      "version": "5.21.0",
+      "size": 2345718,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@typescript-eslint/parser",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@typescript-eslint/parser",
+      "version": "5.21.0",
+      "size": 29648,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@typescript-eslint/scope-manager",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/scope-manager",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@typescript-eslint/scope-manager",
+      "version": "5.21.0",
+      "size": 563952,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@typescript-eslint/type-utils",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/type-utils",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@typescript-eslint/type-utils",
+      "version": "5.21.0",
+      "size": 77349,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@typescript-eslint/types",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/types",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@typescript-eslint/types",
+      "version": "5.21.0",
+      "size": 129322,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@typescript-eslint/typescript-estree",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@typescript-eslint/typescript-estree",
+      "version": "5.21.0",
+      "size": 453002,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@typescript-eslint/utils",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/utils",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@typescript-eslint/utils",
+      "version": "5.21.0",
+      "size": 287259,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@typescript-eslint/visitor-keys",
+      "breadcrumb": "eslint-config-next#@typescript-eslint/parser#@typescript-eslint/scope-manager#@typescript-eslint/visitor-keys",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@typescript-eslint/visitor-keys",
+      "version": "5.10.1",
+      "size": 16649,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@package-inspector/pi-cli",
+      "breadcrumb": "@package-inspector/pi-cli",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@package-inspector/pi-cli",
+      "version": "0.0.0",
+      "size": 138445,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "packages/pi-cli",
+      "breadcrumb": "",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "pi-cli",
+      "version": "0.0.0",
+      "size": 138445,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@package-inspector/pi-ui",
+      "breadcrumb": "@package-inspector/pi-ui",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@package-inspector/pi-ui",
+      "version": "0.1.0",
+      "size": 76726391,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "packages/pi-ui",
+      "breadcrumb": "",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "pi-ui",
+      "version": "0.1.0",
+      "size": 76726391,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "packages/pi-cli/node_modules/chalk",
+      "breadcrumb": "chalk",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "chalk",
+      "version": "5.0.1",
+      "size": 41336,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/acorn-globals/node_modules/acorn",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#acorn-globals#acorn",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "acorn",
+      "version": "7.4.1",
+      "size": 1209760,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/agentkeepalive/node_modules/depd",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#agentkeepalive#depd",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "depd",
+      "version": "1.1.2",
+      "size": 30483,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/ansi-escapes/node_modules/type-fest",
+      "breadcrumb": "jest#@jest/core#jest-watcher#ansi-escapes#type-fest",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "type-fest",
+      "version": "0.21.3",
+      "size": 119053,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/apollo-server-caching/node_modules/lru-cache",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-caching#lru-cache",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "lru-cache",
+      "version": "6.0.0",
+      "size": 15643,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/cacache/node_modules/brace-expansion",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#glob#minimatch#brace-expansion",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "brace-expansion",
+      "version": "2.0.1",
+      "size": 11486,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/apollo-server-core/node_modules/lru-cache",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#lru-cache",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "lru-cache",
+      "version": "6.0.0",
+      "size": 15643,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/cacache/node_modules/minimatch",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#glob#minimatch",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "minimatch",
+      "version": "5.0.1",
+      "size": 36629,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/cli-truncate/node_modules/ansi-regex",
+      "breadcrumb": "lint-staged#cli-truncate#string-width#strip-ansi#ansi-regex",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "ansi-regex",
+      "version": "6.0.1",
+      "size": 5667,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/cacache/node_modules/glob",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#glob",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "glob",
+      "version": "8.0.1",
+      "size": 54890,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/cli-truncate/node_modules/string-width",
+      "breadcrumb": "lint-staged#cli-truncate#string-width",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "string-width",
+      "version": "5.1.2",
+      "size": 5781,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/cli-truncate/node_modules/strip-ansi",
+      "breadcrumb": "lint-staged#cli-truncate#string-width#strip-ansi",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "strip-ansi",
+      "version": "7.0.1",
+      "size": 4090,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/cssstyle/node_modules/cssom",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#cssstyle#cssom",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "cssom",
+      "version": "0.3.8",
+      "size": 48996,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/debug/node_modules/ms",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#agentkeepalive#debug#ms",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "ms",
+      "version": "2.1.2",
+      "size": 6842,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/convert-source-map/node_modules/safe-buffer",
+      "breadcrumb": "jest#@jest/core#@jest/reporters#v8-to-istanbul#convert-source-map#safe-buffer",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "safe-buffer",
+      "version": "5.1.2",
+      "size": 31686,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/domexception/node_modules/webidl-conversions",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#domexception#webidl-conversions",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "webidl-conversions",
+      "version": "5.0.0",
+      "size": 19951,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/escodegen/node_modules/levn",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator#levn",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "levn",
+      "version": "0.3.0",
+      "size": 34032,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/encoding/node_modules/iconv-lite",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#minipass-fetch#encoding#iconv-lite",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "iconv-lite",
+      "version": "0.6.3",
+      "size": 348518,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/escodegen/node_modules/optionator",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "optionator",
+      "version": "0.8.3",
+      "size": 50062,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint/node_modules/doctrine",
+      "breadcrumb": "eslint-config-next#eslint#doctrine",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "doctrine",
+      "version": "3.0.0",
+      "size": 106364,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-import-resolver-node/node_modules/debug",
+      "breadcrumb": "eslint-config-next#eslint-import-resolver-node#debug",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "debug",
+      "version": "2.6.9",
+      "size": 51243,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-import-resolver-node/node_modules/ms",
+      "breadcrumb": "eslint-config-next#eslint-import-resolver-node#debug#ms",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "ms",
+      "version": "2.0.0",
+      "size": 6266,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-plugin-import/node_modules/eslint-import-resolver-node",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-import-resolver-node",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "eslint-import-resolver-node",
+      "version": "0.3.6",
+      "size": 5373,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-plugin-import/node_modules/debug",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#debug",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "debug",
+      "version": "2.6.9",
+      "size": 51243,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-plugin-import/node_modules/ms",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#debug#ms",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "ms",
+      "version": "2.0.0",
+      "size": 6266,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-module-utils/node_modules/find-up",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "find-up",
+      "version": "2.1.0",
+      "size": 4803,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-module-utils/node_modules/debug",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-module-utils#debug",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "debug",
+      "version": "3.2.7",
+      "size": 53255,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-module-utils/node_modules/p-limit",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path#p-locate#p-limit",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "p-limit",
+      "version": "1.3.0",
+      "size": 3963,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-module-utils/node_modules/locate-path",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "locate-path",
+      "version": "2.0.0",
+      "size": 3969,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-module-utils/node_modules/p-locate",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path#p-locate",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "p-locate",
+      "version": "2.0.0",
+      "size": 5053,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-module-utils/node_modules/path-exists",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path#path-exists",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "path-exists",
+      "version": "3.0.0",
+      "size": 3316,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-plugin-react/node_modules/semver",
+      "breadcrumb": "eslint-config-next#eslint-plugin-react#semver",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "semver",
+      "version": "6.3.0",
+      "size": 67071,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-module-utils/node_modules/p-try",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path#p-locate#p-limit#p-try",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "p-try",
+      "version": "1.0.0",
+      "size": 2798,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-plugin-react/node_modules/resolve",
+      "breadcrumb": "eslint-config-next#eslint-plugin-react#resolve",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "resolve",
+      "version": "2.0.0-next.3",
+      "size": 111764,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-utils/node_modules/eslint-visitor-keys",
+      "breadcrumb": "eslint-config-next#eslint#eslint-utils#eslint-visitor-keys",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "eslint-visitor-keys",
+      "version": "2.1.0",
+      "size": 24680,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/execa/node_modules/is-stream",
+      "breadcrumb": "jest#@jest/core#jest-changed-files#execa#is-stream",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-stream",
+      "version": "2.0.1",
+      "size": 5927,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/fast-glob/node_modules/glob-parent",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#fast-glob#glob-parent",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "glob-parent",
+      "version": "5.1.2",
+      "size": 12134,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/http-errors/node_modules/inherits",
+      "breadcrumb": "apollo-server-micro#micro#raw-body#http-errors#inherits",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "inherits",
+      "version": "2.0.3",
+      "size": 3824,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/graphql-tag/node_modules/tslib",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#graphql-tag#tslib",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "tslib",
+      "version": "2.4.0",
+      "size": 49968,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/ignore-walk/node_modules/brace-expansion",
+      "breadcrumb": "@npmcli/arborist#pacote#npm-packlist#ignore-walk#minimatch#brace-expansion",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "brace-expansion",
+      "version": "2.0.1",
+      "size": 11486,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/ignore-walk/node_modules/minimatch",
+      "breadcrumb": "@npmcli/arborist#pacote#npm-packlist#ignore-walk#minimatch",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "minimatch",
+      "version": "5.0.1",
+      "size": 36629,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/import-fresh/node_modules/resolve-from",
+      "breadcrumb": "eslint-config-next#eslint#import-fresh#resolve-from",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "resolve-from",
+      "version": "4.0.0",
+      "size": 4641,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/istanbul-lib-instrument/node_modules/semver",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#istanbul-lib-instrument#semver",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "semver",
+      "version": "6.3.0",
+      "size": 67071,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-cli/node_modules/yargs",
+      "breadcrumb": "jest#jest-cli#yargs",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "yargs",
+      "version": "16.2.0",
+      "size": 286271,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-runtime/node_modules/strip-bom",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-runtime#strip-bom",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "strip-bom",
+      "version": "4.0.0",
+      "size": 3910,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-cli/node_modules/yargs-parser",
+      "breadcrumb": "jest#jest-cli#yargs#yargs-parser",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "yargs-parser",
+      "version": "20.2.9",
+      "size": 124417,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jest-worker/node_modules/supports-color",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-resolve#jest-haste-map#jest-worker#supports-color",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "supports-color",
+      "version": "8.1.1",
+      "size": 8452,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/levn/node_modules/prelude-ls",
+      "breadcrumb": "eslint-config-next#eslint#levn#prelude-ls",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "prelude-ls",
+      "version": "1.2.1",
+      "size": 36741,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/lint-staged/node_modules/supports-color",
+      "breadcrumb": "lint-staged#supports-color",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "supports-color",
+      "version": "9.2.2",
+      "size": 10408,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/listr2/node_modules/cli-truncate",
+      "breadcrumb": "lint-staged#listr2#cli-truncate",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "cli-truncate",
+      "version": "2.1.0",
+      "size": 10357,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/levn/node_modules/type-check",
+      "breadcrumb": "eslint-config-next#eslint#levn#type-check",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "type-check",
+      "version": "0.4.0",
+      "size": 21167,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/listr2/node_modules/slice-ansi",
+      "breadcrumb": "lint-staged#listr2#cli-truncate#slice-ansi",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "slice-ansi",
+      "version": "3.0.0",
+      "size": 6204,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/log-update/node_modules/slice-ansi",
+      "breadcrumb": "lint-staged#listr2#log-update#slice-ansi",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "slice-ansi",
+      "version": "4.0.0",
+      "size": 6434,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/make-dir/node_modules/semver",
+      "breadcrumb": "jest#@jest/core#@jest/reporters#istanbul-reports#istanbul-lib-report#make-dir#semver",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "semver",
+      "version": "6.3.0",
+      "size": 67071,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/log-update/node_modules/wrap-ansi",
+      "breadcrumb": "lint-staged#listr2#log-update#wrap-ansi",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "wrap-ansi",
+      "version": "6.2.0",
+      "size": 9500,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/node-fetch/node_modules/tr46",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-env#node-fetch#whatwg-url#tr46",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "tr46",
+      "version": "0.0.3",
+      "size": 268388,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/node-fetch/node_modules/webidl-conversions",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-env#node-fetch#whatwg-url#webidl-conversions",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "webidl-conversions",
+      "version": "3.0.1",
+      "size": 12370,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/node-fetch/node_modules/whatwg-url",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-env#node-fetch#whatwg-url",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "whatwg-url",
+      "version": "5.0.0",
+      "size": 49886,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/npm-packlist/node_modules/brace-expansion",
+      "breadcrumb": "@npmcli/arborist#pacote#npm-packlist#glob#minimatch#brace-expansion",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "brace-expansion",
+      "version": "2.0.1",
+      "size": 11486,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/npm-packlist/node_modules/glob",
+      "breadcrumb": "@npmcli/arborist#pacote#npm-packlist#glob",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "glob",
+      "version": "8.0.1",
+      "size": 54890,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/npm-packlist/node_modules/minimatch",
+      "breadcrumb": "@npmcli/arborist#pacote#npm-packlist#glob#minimatch",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "minimatch",
+      "version": "5.0.1",
+      "size": 36629,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/pretty-format/node_modules/ansi-styles",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#pretty-format#ansi-styles",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "ansi-styles",
+      "version": "5.2.0",
+      "size": 13596,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/optionator/node_modules/prelude-ls",
+      "breadcrumb": "eslint-config-next#eslint#optionator#prelude-ls",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "prelude-ls",
+      "version": "1.2.1",
+      "size": 36741,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/optionator/node_modules/type-check",
+      "breadcrumb": "eslint-config-next#eslint#optionator#type-check",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "type-check",
+      "version": "0.4.0",
+      "size": 21167,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/promise-retry/node_modules/retry",
+      "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#promise-retry#retry",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "retry",
+      "version": "0.12.0",
+      "size": 32210,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/prop-types/node_modules/react-is",
+      "breadcrumb": "eslint-config-next#eslint-plugin-react#prop-types#react-is",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "react-is",
+      "version": "16.13.1",
+      "size": 23954,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/read-package-json/node_modules/brace-expansion",
+      "breadcrumb": "@npmcli/arborist#pacote#read-package-json#glob#minimatch#brace-expansion",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "brace-expansion",
+      "version": "2.0.1",
+      "size": 11486,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/read-package-json/node_modules/glob",
+      "breadcrumb": "@npmcli/arborist#pacote#read-package-json#glob",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "glob",
+      "version": "8.0.1",
+      "size": 54890,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/read-package-json/node_modules/minimatch",
+      "breadcrumb": "@npmcli/arborist#pacote#read-package-json#glob#minimatch",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "minimatch",
+      "version": "5.0.1",
+      "size": 36629,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/rxjs/node_modules/tslib",
+      "breadcrumb": "lint-staged#listr2#rxjs#tslib",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "tslib",
+      "version": "2.4.0",
+      "size": 49968,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/semver/node_modules/lru-cache",
+      "breadcrumb": "@npmcli/arborist#pacote#npm-pick-manifest#npm-package-arg#validate-npm-package-name#builtins#semver#lru-cache",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "lru-cache",
+      "version": "6.0.0",
+      "size": 15643,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/slice-ansi/node_modules/ansi-styles",
+      "breadcrumb": "lint-staged#cli-truncate#slice-ansi#ansi-styles",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "ansi-styles",
+      "version": "6.1.0",
+      "size": 15535,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/slice-ansi/node_modules/is-fullwidth-code-point",
+      "breadcrumb": "lint-staged#cli-truncate#slice-ansi#is-fullwidth-code-point",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "is-fullwidth-code-point",
+      "version": "4.0.0",
+      "size": 5189,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/stack-utils/node_modules/escape-string-regexp",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#stack-utils#escape-string-regexp",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "escape-string-regexp",
+      "version": "2.0.0",
+      "size": 3259,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/string-width/node_modules/emoji-regex",
+      "breadcrumb": "yargs#cliui#string-width#emoji-regex",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "emoji-regex",
+      "version": "8.0.0",
+      "size": 48255,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/tsutils/node_modules/tslib",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#tsutils#tslib",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "tslib",
+      "version": "1.14.1",
+      "size": 33965,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/v8-to-istanbul/node_modules/source-map",
+      "breadcrumb": "jest#@jest/core#@jest/reporters#v8-to-istanbul#source-map",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "source-map",
+      "version": "0.7.3",
+      "size": 311689,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/whatwg-encoding/node_modules/iconv-lite",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#html-encoding-sniffer#whatwg-encoding#iconv-lite",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "iconv-lite",
+      "version": "0.4.24",
+      "size": 335941,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/core/node_modules/json5",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#json5",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "json5",
+      "version": "2.2.1",
+      "size": 228701,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/xss/node_modules/commander",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#@apollographql/graphql-playground-html#xss#commander",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "commander",
+      "version": "2.20.3",
+      "size": 62442,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/core/node_modules/semver",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#semver",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "semver",
+      "version": "6.3.0",
+      "size": 67071,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/generator/node_modules/source-map",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-snapshot#@babel/generator#source-map",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "source-map",
+      "version": "0.5.7",
+      "size": 766471,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/highlight/node_modules/ansi-styles",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#ansi-styles",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "ansi-styles",
+      "version": "3.2.1",
+      "size": 9371,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/helper-compilation-targets/node_modules/semver",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#@babel/helper-compilation-targets#semver",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "semver",
+      "version": "6.3.0",
+      "size": 67071,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/highlight/node_modules/chalk",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "chalk",
+      "version": "2.4.2",
+      "size": 26924,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/highlight/node_modules/color-convert",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#ansi-styles#color-convert",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "color-convert",
+      "version": "1.9.3",
+      "size": 26964,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/highlight/node_modules/color-name",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#ansi-styles#color-convert#color-name",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "color-name",
+      "version": "1.1.3",
+      "size": 9360,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/highlight/node_modules/has-flag",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#supports-color#has-flag",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "has-flag",
+      "version": "3.0.0",
+      "size": 3125,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/highlight/node_modules/supports-color",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#supports-color",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "supports-color",
+      "version": "5.5.0",
+      "size": 6630,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/traverse/node_modules/globals",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-snapshot#@babel/traverse#globals",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "globals",
+      "version": "11.12.0",
+      "size": 39779,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@istanbuljs/load-nyc-config#js-yaml#argparse",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "argparse",
+      "version": "1.0.10",
+      "size": 116446,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@babel/highlight/node_modules/escape-string-regexp",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#escape-string-regexp",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "escape-string-regexp",
+      "version": "1.0.5",
+      "size": 2688,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@istanbuljs/load-nyc-config#camelcase",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "camelcase",
+      "version": "5.3.1",
+      "size": 7447,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@jest/transform/node_modules/write-file-atomic",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@jest/transform#write-file-atomic",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "write-file-atomic",
+      "version": "3.0.3",
+      "size": 12787,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml",
+      "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@istanbuljs/load-nyc-config#js-yaml",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "js-yaml",
+      "version": "3.14.1",
+      "size": 291327,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@npmcli/map-workspaces/node_modules/brace-expansion",
+      "breadcrumb": "@npmcli/arborist#@npmcli/map-workspaces#minimatch#brace-expansion",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "brace-expansion",
+      "version": "2.0.1",
+      "size": 11486,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@npmcli/map-workspaces/node_modules/glob",
+      "breadcrumb": "@npmcli/arborist#@npmcli/map-workspaces#glob",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "glob",
+      "version": "8.0.1",
+      "size": 54890,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@npmcli/map-workspaces/node_modules/minimatch",
+      "breadcrumb": "@npmcli/arborist#@npmcli/map-workspaces#minimatch",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "minimatch",
+      "version": "5.0.1",
+      "size": 36629,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@typescript-eslint/utils/node_modules/eslint-scope",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/utils#eslint-scope",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "eslint-scope",
+      "version": "5.1.1",
+      "size": 78356,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@next/eslint-plugin-next/node_modules/glob",
+      "breadcrumb": "eslint-config-next#@next/eslint-plugin-next#glob",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "glob",
+      "version": "7.1.7",
+      "size": 55910,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@typescript-eslint/utils/node_modules/estraverse",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/utils#eslint-scope#estraverse",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "estraverse",
+      "version": "4.3.0",
+      "size": 36325,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jsdom/node_modules/http-proxy-agent",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#http-proxy-agent",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "http-proxy-agent",
+      "version": "4.0.1",
+      "size": 17062,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-config-next/node_modules/@typescript-eslint/parser",
+      "breadcrumb": "eslint-config-next#@typescript-eslint/parser",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@typescript-eslint/parser",
+      "version": "5.10.1",
+      "size": 29036,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-config-next/node_modules/@typescript-eslint/scope-manager",
+      "breadcrumb": "eslint-config-next#@typescript-eslint/parser#@typescript-eslint/scope-manager",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@typescript-eslint/scope-manager",
+      "version": "5.10.1",
+      "size": 543482,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-config-next/node_modules/@typescript-eslint/typescript-estree",
+      "breadcrumb": "eslint-config-next#@typescript-eslint/parser#@typescript-eslint/typescript-estree",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@typescript-eslint/typescript-estree",
+      "version": "5.10.1",
+      "size": 450787,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-config-next/node_modules/@typescript-eslint/types",
+      "breadcrumb": "eslint-config-next#@typescript-eslint/parser#@typescript-eslint/types",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@typescript-eslint/types",
+      "version": "5.10.1",
+      "size": 128174,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/jsdom/node_modules/@tootallnate/once",
+      "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#http-proxy-agent#@tootallnate/once",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@tootallnate/once",
+      "version": "1.1.2",
+      "size": 4085,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@apollo/protobufjs/node_modules/@types/node",
+      "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@types/node",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@types/node",
+      "version": "10.17.60",
+      "size": 631948,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@typescript-eslint/scope-manager/node_modules/@typescript-eslint/visitor-keys",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/scope-manager#@typescript-eslint/visitor-keys",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@typescript-eslint/visitor-keys",
+      "version": "5.21.0",
+      "size": 16870,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/types",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#@typescript-eslint/types",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@typescript-eslint/types",
+      "version": "3.10.1",
+      "size": 114473,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/visitor-keys",
+      "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#@typescript-eslint/visitor-keys",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@typescript-eslint/visitor-keys",
+      "version": "5.21.0",
+      "size": 16870,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/@typescript-eslint/visitor-keys/node_modules/@typescript-eslint/types",
+      "breadcrumb": "eslint-config-next#@typescript-eslint/parser#@typescript-eslint/scope-manager#@typescript-eslint/visitor-keys#@typescript-eslint/types",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "@typescript-eslint/types",
+      "version": "5.10.1",
+      "size": 128174,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-plugin-import/node_modules/eslint-import-resolver-node/node_modules/ms",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-import-resolver-node#debug#ms",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "ms",
+      "version": "2.1.3",
+      "size": 6721,
+      "dependencies": [],
+      "devDependencies": []
+    },
+    {
+      "pathOnDisk": "node_modules/eslint-plugin-import/node_modules/eslint-import-resolver-node/node_modules/debug",
+      "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-import-resolver-node#debug",
+      "funding": "N/A",
+      "homepage": "N/A",
+      "name": "debug",
+      "version": "3.2.7",
+      "size": 53255,
+      "dependencies": [],
+      "devDependencies": []
+    }
+  ],
+  "suggestions": [
+    {
+      "id": "packagesWithPinnedVersions",
+      "name": "Packages with pinned dependencies",
+      "message": "There are currently 16 packages with pinned versions which will never collapse those dependencies causing an additional 2.3 MiB",
+      "actions": [
+        {
+          "message": "\"language-tags\" (eslint-config-next#eslint-plugin-jsx-a11y#language-tags) has a pinned version for language-subtag-registry@~0.3.2 that will never collapse.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint-plugin-jsx-a11y#language-tags",
+            "name": "language-tags",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/language-tags",
+            "version": "~0.3.2",
+            "size": 1536902
+          }
+        },
+        {
+          "message": "\"whatwg-url\" (apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-env#node-fetch#whatwg-url) has a pinned version for tr46@~0.0.3 that will never collapse.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-env#node-fetch#whatwg-url",
+            "name": "whatwg-url",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/node-fetch/node_modules/whatwg-url",
+            "version": "~0.0.3",
+            "size": 268388
+          }
+        },
+        {
+          "message": "\"cssstyle\" (jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#cssstyle) has a pinned version for cssom@~0.3.6 that will never collapse.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#cssstyle",
+            "name": "cssstyle",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/cssstyle",
+            "version": "~0.3.6",
+            "size": 48996
+          }
+        },
+        {
+          "message": "\"@graphql-tools/mock\" (apollo-server-micro#apollo-server-core#@graphql-tools/mock) has a pinned version for tslib@~2.3.0 that will never collapse.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#apollo-server-core#@graphql-tools/mock",
+            "name": "@graphql-tools/mock",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@graphql-tools/mock",
+            "version": "~2.3.0",
+            "size": 39088
+          }
+        },
+        {
+          "message": "\"@graphql-tools/schema\" (apollo-server-micro#apollo-server-core#@graphql-tools/schema) has a pinned version for tslib@~2.3.0 that will never collapse.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#apollo-server-core#@graphql-tools/schema",
+            "name": "@graphql-tools/schema",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@graphql-tools/schema",
+            "version": "~2.3.0",
+            "size": 39088
+          }
+        },
+        {
+          "message": "\"@graphql-tools/utils\" (apollo-server-micro#apollo-server-core#@graphql-tools/mock#@graphql-tools/utils) has a pinned version for tslib@~2.3.0 that will never collapse.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#apollo-server-core#@graphql-tools/mock#@graphql-tools/utils",
+            "name": "@graphql-tools/utils",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@graphql-tools/utils",
+            "version": "~2.3.0",
+            "size": 39088
+          }
+        },
+        {
+          "message": "\"@graphql-tools/merge\" (apollo-server-micro#apollo-server-core#@graphql-tools/schema#@graphql-tools/merge) has a pinned version for tslib@~2.3.0 that will never collapse.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#apollo-server-core#@graphql-tools/schema#@graphql-tools/merge",
+            "name": "@graphql-tools/merge",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@graphql-tools/merge",
+            "version": "~2.3.0",
+            "size": 39088
+          }
+        },
+        {
+          "message": "\"type-check\" (jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator#levn#type-check) has a pinned version for prelude-ls@~1.1.2 that will never collapse.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator#levn#type-check",
+            "name": "type-check",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/type-check",
+            "version": "~1.1.2",
+            "size": 36015
+          }
+        },
+        {
+          "message": "\"levn\" (jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator#levn) has a pinned version for prelude-ls@~1.1.2 that will never collapse.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator#levn",
+            "name": "levn",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/escodegen/node_modules/levn",
+            "version": "~1.1.2",
+            "size": 36015
+          }
+        },
+        {
+          "message": "\"optionator\" (jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator) has a pinned version for prelude-ls@~1.1.2 that will never collapse.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator",
+            "name": "optionator",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/escodegen/node_modules/optionator",
+            "version": "~1.1.2",
+            "size": 36015
+          }
+        },
+        {
+          "message": "\"argparse\" (jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@istanbuljs/load-nyc-config#js-yaml#argparse) has a pinned version for sprintf-js@~1.0.2 that will never collapse.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@istanbuljs/load-nyc-config#js-yaml#argparse",
+            "name": "argparse",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@istanbuljs/load-nyc-config/node_modules/argparse",
+            "version": "~1.0.2",
+            "size": 34784
+          }
+        },
+        {
+          "message": "\"optionator\" (jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator) has a pinned version for levn@~0.3.0 that will never collapse.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator",
+            "name": "optionator",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/escodegen/node_modules/optionator",
+            "version": "~0.3.0",
+            "size": 34032
+          }
+        },
+        {
+          "message": "\"string_decoder\" (@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#npmlog#are-we-there-yet#readable-stream#string_decoder) has a pinned version for safe-buffer@~5.2.0 that will never collapse.",
+          "meta": {
+            "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#npmlog#are-we-there-yet#readable-stream#string_decoder",
+            "name": "string_decoder",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/string_decoder",
+            "version": "~5.2.0",
+            "size": 32101
+          }
+        },
+        {
+          "message": "\"convert-source-map\" (jest#@jest/core#@jest/reporters#v8-to-istanbul#convert-source-map) has a pinned version for safe-buffer@~5.1.1 that will never collapse.",
+          "meta": {
+            "breadcrumb": "jest#@jest/core#@jest/reporters#v8-to-istanbul#convert-source-map",
+            "name": "convert-source-map",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/convert-source-map",
+            "version": "~5.1.1",
+            "size": 31686
+          }
+        },
+        {
+          "message": "\"levn\" (eslint-config-next#eslint#levn) has a pinned version for type-check@~0.4.0 that will never collapse.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint#levn",
+            "name": "levn",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/levn",
+            "version": "~0.4.0",
+            "size": 21167
+          }
+        },
+        {
+          "message": "\"levn\" (jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator#levn) has a pinned version for type-check@~0.3.2 that will never collapse.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator#levn",
+            "name": "levn",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/escodegen/node_modules/levn",
+            "version": "~0.3.2",
+            "size": 20856
+          }
+        },
+        {
+          "message": "\"optionator\" (jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator) has a pinned version for type-check@~0.3.2 that will never collapse.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator",
+            "name": "optionator",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/escodegen/node_modules/optionator",
+            "version": "~0.3.2",
+            "size": 20856
+          }
+        },
+        {
+          "message": "\"type-is\" (apollo-server-micro#type-is) has a pinned version for mime-types@~2.1.24 that will never collapse.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#type-is",
+            "name": "type-is",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/type-is",
+            "version": "~2.1.24",
+            "size": 18272
+          }
+        },
+        {
+          "message": "\"optionator\" (jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator) has a pinned version for word-wrap@~1.2.3 that will never collapse.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator",
+            "name": "optionator",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/escodegen/node_modules/optionator",
+            "version": "~1.2.3",
+            "size": 10584
+          }
+        },
+        {
+          "message": "\"optionator\" (jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator) has a pinned version for fast-levenshtein@~2.0.6 that will never collapse.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator",
+            "name": "optionator",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/escodegen/node_modules/optionator",
+            "version": "~2.0.6",
+            "size": 9444
+          }
+        },
+        {
+          "message": "\"optionator\" (jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator) has a pinned version for deep-is@~0.1.3 that will never collapse.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator",
+            "name": "optionator",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/escodegen/node_modules/optionator",
+            "version": "~0.1.3",
+            "size": 8114
+          }
+        },
+        {
+          "message": "\"combined-stream\" (jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#form-data#combined-stream) has a pinned version for delayed-stream@~1.0.0 that will never collapse.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#form-data#combined-stream",
+            "name": "combined-stream",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/combined-stream",
+            "version": "~1.0.0",
+            "size": 8021
+          }
+        },
+        {
+          "message": "\"color-convert\" (jest#jest-cli#jest-config#babel-jest#chalk#ansi-styles#color-convert) has a pinned version for color-name@~1.1.4 that will never collapse.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#chalk#ansi-styles#color-convert",
+            "name": "color-convert",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/color-convert",
+            "version": "~1.1.4",
+            "size": 6693
+          }
+        }
+      ]
+    },
+    {
+      "id": "packagesWithExtraArtifacts",
+      "name": "Packages with extra artifacts",
+      "message": "There are currently 18 packages with artifacts that are superflous and are not necessary for production usage. 667.4 KiB",
+      "actions": [
+        {
+          "message": "\"@typescript-eslint/eslint-plugin\" (@typescript-eslint/eslint-plugin) has a \"docs\" folder which is not necessary for production usage 380.1 KiB.",
+          "meta": {
+            "breadcrumb": "@typescript-eslint/eslint-plugin",
+            "name": "@typescript-eslint/eslint-plugin",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@typescript-eslint/eslint-plugin",
+            "version": "5.21.0",
+            "size": 389204
+          }
+        },
+        {
+          "message": "\"eslint-plugin-import\" (eslint-config-next#eslint-plugin-import) has a \"docs\" folder which is not necessary for production usage 84.6 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint-plugin-import",
+            "name": "eslint-plugin-import",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-plugin-import",
+            "version": "2.25.2",
+            "size": 86646
+          }
+        },
+        {
+          "message": "\"eslint-plugin-jsx-a11y\" (eslint-config-next#eslint-plugin-jsx-a11y) has a \"docs\" folder which is not necessary for production usage 79.2 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint-plugin-jsx-a11y",
+            "name": "eslint-plugin-jsx-a11y",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-plugin-jsx-a11y",
+            "version": "6.5.1",
+            "size": 81139
+          }
+        },
+        {
+          "message": "\"socks\" (@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#socks-proxy-agent#socks) has a \"docs\" folder which is not necessary for production usage 29.9 KiB.",
+          "meta": {
+            "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#socks-proxy-agent#socks",
+            "name": "socks",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/socks",
+            "version": "2.6.2",
+            "size": 30638
+          }
+        },
+        {
+          "message": "\"@humanwhocodes/object-schema\" (eslint-config-next#eslint#@humanwhocodes/config-array#@humanwhocodes/object-schema) has a \"tests\" folder which is not necessary for production usage 25.8 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint#@humanwhocodes/config-array#@humanwhocodes/object-schema",
+            "name": "@humanwhocodes/object-schema",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@humanwhocodes/object-schema",
+            "version": "1.2.1",
+            "size": 26368
+          }
+        },
+        {
+          "message": "\"node-gyp\" (@npmcli/arborist#pacote#@npmcli/run-script#node-gyp) has a \"docs\" folder which is not necessary for production usage 18.6 KiB.",
+          "meta": {
+            "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp",
+            "name": "node-gyp",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/node-gyp",
+            "version": "9.0.0",
+            "size": 19075
+          }
+        },
+        {
+          "message": "\"@protobufjs/utf8\" (apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/utf8) has a \"tests\" folder which is not necessary for production usage 16.2 KiB.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/utf8",
+            "name": "@protobufjs/utf8",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@protobufjs/utf8",
+            "version": "1.1.0",
+            "size": 16625
+          }
+        },
+        {
+          "message": "\"smart-buffer\" (@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#socks-proxy-agent#socks#smart-buffer) has a \"docs\" folder which is not necessary for production usage 14.5 KiB.",
+          "meta": {
+            "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#socks-proxy-agent#socks#smart-buffer",
+            "name": "smart-buffer",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/smart-buffer",
+            "version": "4.2.0",
+            "size": 14868
+          }
+        },
+        {
+          "message": "\"@protobufjs/aspromise\" (apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/aspromise) has a \"tests\" folder which is not necessary for production usage 4.4 KiB.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/aspromise",
+            "name": "@protobufjs/aspromise",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@protobufjs/aspromise",
+            "version": "1.1.2",
+            "size": 4455
+          }
+        },
+        {
+          "message": "\"wcwidth\" (ora#wcwidth) has a \"docs\" folder which is not necessary for production usage 3.1 KiB.",
+          "meta": {
+            "breadcrumb": "ora#wcwidth",
+            "name": "wcwidth",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/wcwidth",
+            "version": "1.0.1",
+            "size": 3218
+          }
+        },
+        {
+          "message": "\"@protobufjs/float\" (apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/float) has a \"tests\" folder which is not necessary for production usage 3.0 KiB.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/float",
+            "name": "@protobufjs/float",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@protobufjs/float",
+            "version": "1.0.2",
+            "size": 3102
+          }
+        },
+        {
+          "message": "\"@protobufjs/path\" (apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/path) has a \"tests\" folder which is not necessary for production usage 2.0 KiB.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/path",
+            "name": "@protobufjs/path",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@protobufjs/path",
+            "version": "1.1.2",
+            "size": 2089
+          }
+        },
+        {
+          "message": "\"@protobufjs/pool\" (apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/pool) has a \"tests\" folder which is not necessary for production usage 1.5 KiB.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/pool",
+            "name": "@protobufjs/pool",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@protobufjs/pool",
+            "version": "1.1.0",
+            "size": 1517
+          }
+        },
+        {
+          "message": "\"@protobufjs/eventemitter\" (apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/eventemitter) has a \"tests\" folder which is not necessary for production usage 1.5 KiB.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/eventemitter",
+            "name": "@protobufjs/eventemitter",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@protobufjs/eventemitter",
+            "version": "1.1.0",
+            "size": 1488
+          }
+        },
+        {
+          "message": "\"@protobufjs/base64\" (apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/base64) has a \"tests\" folder which is not necessary for production usage 1.3 KiB.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/base64",
+            "name": "@protobufjs/base64",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@protobufjs/base64",
+            "version": "1.1.2",
+            "size": 1371
+          }
+        },
+        {
+          "message": "\"@protobufjs/inquire\" (apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/inquire) has a \"tests\" folder which is not necessary for production usage 887 B.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/inquire",
+            "name": "@protobufjs/inquire",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@protobufjs/inquire",
+            "version": "1.1.0",
+            "size": 887
+          }
+        },
+        {
+          "message": "\"@protobufjs/fetch\" (apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/fetch) has a \"tests\" folder which is not necessary for production usage 410 B.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/fetch",
+            "name": "@protobufjs/fetch",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@protobufjs/fetch",
+            "version": "1.1.0",
+            "size": 410
+          }
+        },
+        {
+          "message": "\"@protobufjs/codegen\" (apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/codegen) has a \"tests\" folder which is not necessary for production usage 356 B.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@protobufjs/codegen",
+            "name": "@protobufjs/codegen",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@protobufjs/codegen",
+            "version": "2.0.4",
+            "size": 356
+          }
+        }
+      ]
+    },
+    {
+      "id": "notBeingAbsorbedByTopLevel",
+      "name": "Dependencies not being absorbed",
+      "message": "There are currently 113 duplicate packages being installed on disk because they are not being absorbed into the top level semver range. This equates to a total of 8.6 MiB",
+      "actions": [
+        {
+          "message": "\"acorn\" (jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#acorn-globals#acorn) not absorbed because top level dep is \"8.7.0\" and this is \"7.4.1\". This takes up an additional 1.2 MiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#acorn-globals#acorn",
+            "name": "acorn",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/acorn-globals/node_modules/acorn",
+            "version": "7.4.1",
+            "size": 1209760
+          }
+        },
+        {
+          "message": "\"source-map\" (jest#jest-cli#jest-config#jest-circus#jest-snapshot#@babel/generator#source-map) not absorbed because top level dep is \"0.6.1\" and this is \"0.5.7\". This takes up an additional 748.5 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-snapshot#@babel/generator#source-map",
+            "name": "source-map",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@babel/generator/node_modules/source-map",
+            "version": "0.5.7",
+            "size": 766471
+          }
+        },
+        {
+          "message": "\"@types/node\" (apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@types/node) not absorbed because top level dep is \"17.0.27\" and this is \"10.17.60\". This takes up an additional 617.1 KiB.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@types/node",
+            "name": "@types/node",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@apollo/protobufjs/node_modules/@types/node",
+            "version": "10.17.60",
+            "size": 631948
+          }
+        },
+        {
+          "message": "\"@typescript-eslint/scope-manager\" (eslint-config-next#@typescript-eslint/parser#@typescript-eslint/scope-manager) not absorbed because top level dep is \"5.21.0\" and this is \"5.10.1\". This takes up an additional 530.7 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#@typescript-eslint/parser#@typescript-eslint/scope-manager",
+            "name": "@typescript-eslint/scope-manager",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-config-next/node_modules/@typescript-eslint/scope-manager",
+            "version": "5.10.1",
+            "size": 543482
+          }
+        },
+        {
+          "message": "\"@typescript-eslint/typescript-estree\" (eslint-config-next#@typescript-eslint/parser#@typescript-eslint/typescript-estree) not absorbed because top level dep is \"5.21.0\" and this is \"5.10.1\". This takes up an additional 440.2 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#@typescript-eslint/parser#@typescript-eslint/typescript-estree",
+            "name": "@typescript-eslint/typescript-estree",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-config-next/node_modules/@typescript-eslint/typescript-estree",
+            "version": "5.10.1",
+            "size": 450787
+          }
+        },
+        {
+          "message": "\"iconv-lite\" (@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#minipass-fetch#encoding#iconv-lite) not absorbed because top level dep is \"0.4.19\" and this is \"0.6.3\". This takes up an additional 340.3 KiB.",
+          "meta": {
+            "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#minipass-fetch#encoding#iconv-lite",
+            "name": "iconv-lite",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/encoding/node_modules/iconv-lite",
+            "version": "0.6.3",
+            "size": 348518
+          }
+        },
+        {
+          "message": "\"iconv-lite\" (jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#html-encoding-sniffer#whatwg-encoding#iconv-lite) not absorbed because top level dep is \"0.4.19\" and this is \"0.4.24\". This takes up an additional 328.1 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#html-encoding-sniffer#whatwg-encoding#iconv-lite",
+            "name": "iconv-lite",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/whatwg-encoding/node_modules/iconv-lite",
+            "version": "0.4.24",
+            "size": 335941
+          }
+        },
+        {
+          "message": "\"source-map\" (jest#@jest/core#@jest/reporters#v8-to-istanbul#source-map) not absorbed because top level dep is \"0.6.1\" and this is \"0.7.3\". This takes up an additional 304.4 KiB.",
+          "meta": {
+            "breadcrumb": "jest#@jest/core#@jest/reporters#v8-to-istanbul#source-map",
+            "name": "source-map",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/v8-to-istanbul/node_modules/source-map",
+            "version": "0.7.3",
+            "size": 311689
+          }
+        },
+        {
+          "message": "\"js-yaml\" (jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@istanbuljs/load-nyc-config#js-yaml) not absorbed because top level dep is \"4.1.0\" and this is \"3.14.1\". This takes up an additional 284.5 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@istanbuljs/load-nyc-config#js-yaml",
+            "name": "js-yaml",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml",
+            "version": "3.14.1",
+            "size": 291327
+          }
+        },
+        {
+          "message": "\"yargs\" (jest#jest-cli#yargs) not absorbed because top level dep is \"17.4.1\" and this is \"16.2.0\". This takes up an additional 279.6 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#yargs",
+            "name": "yargs",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-cli/node_modules/yargs",
+            "version": "16.2.0",
+            "size": 286271
+          }
+        },
+        {
+          "message": "\"tr46\" (apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-env#node-fetch#whatwg-url#tr46) not absorbed because top level dep is \"2.1.0\" and this is \"0.0.3\". This takes up an additional 262.1 KiB.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-env#node-fetch#whatwg-url#tr46",
+            "name": "tr46",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/node-fetch/node_modules/tr46",
+            "version": "0.0.3",
+            "size": 268388
+          }
+        },
+        {
+          "message": "\"json5\" (jest#jest-cli#jest-config#babel-jest#@babel/core#json5) not absorbed because top level dep is \"1.0.1\" and this is \"2.2.1\". This takes up an additional 223.3 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#json5",
+            "name": "json5",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@babel/core/node_modules/json5",
+            "version": "2.2.1",
+            "size": 228701
+          }
+        },
+        {
+          "message": "\"@typescript-eslint/types\" (eslint-config-next#@typescript-eslint/parser#@typescript-eslint/types) not absorbed because top level dep is \"5.21.0\" and this is \"5.10.1\". This takes up an additional 125.2 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#@typescript-eslint/parser#@typescript-eslint/types",
+            "name": "@typescript-eslint/types",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-config-next/node_modules/@typescript-eslint/types",
+            "version": "5.10.1",
+            "size": 128174
+          }
+        },
+        {
+          "message": "\"@typescript-eslint/types\" (eslint-config-next#@typescript-eslint/parser#@typescript-eslint/scope-manager#@typescript-eslint/visitor-keys#@typescript-eslint/types) not absorbed because top level dep is \"5.21.0\" and this is \"5.10.1\". This takes up an additional 125.2 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#@typescript-eslint/parser#@typescript-eslint/scope-manager#@typescript-eslint/visitor-keys#@typescript-eslint/types",
+            "name": "@typescript-eslint/types",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@typescript-eslint/visitor-keys/node_modules/@typescript-eslint/types",
+            "version": "5.10.1",
+            "size": 128174
+          }
+        },
+        {
+          "message": "\"yargs-parser\" (jest#jest-cli#yargs#yargs-parser) not absorbed because top level dep is \"21.0.1\" and this is \"20.2.9\". This takes up an additional 121.5 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#yargs#yargs-parser",
+            "name": "yargs-parser",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-cli/node_modules/yargs-parser",
+            "version": "20.2.9",
+            "size": 124417
+          }
+        },
+        {
+          "message": "\"type-fest\" (jest#@jest/core#jest-watcher#ansi-escapes#type-fest) not absorbed because top level dep is \"0.20.2\" and this is \"0.21.3\". This takes up an additional 116.3 KiB.",
+          "meta": {
+            "breadcrumb": "jest#@jest/core#jest-watcher#ansi-escapes#type-fest",
+            "name": "type-fest",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/ansi-escapes/node_modules/type-fest",
+            "version": "0.21.3",
+            "size": 119053
+          }
+        },
+        {
+          "message": "\"argparse\" (jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@istanbuljs/load-nyc-config#js-yaml#argparse) not absorbed because top level dep is \"2.0.1\" and this is \"1.0.10\". This takes up an additional 113.7 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@istanbuljs/load-nyc-config#js-yaml#argparse",
+            "name": "argparse",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@istanbuljs/load-nyc-config/node_modules/argparse",
+            "version": "1.0.10",
+            "size": 116446
+          }
+        },
+        {
+          "message": "\"@typescript-eslint/types\" (@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#@typescript-eslint/types) not absorbed because top level dep is \"5.21.0\" and this is \"3.10.1\". This takes up an additional 111.8 KiB.",
+          "meta": {
+            "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#@typescript-eslint/types",
+            "name": "@typescript-eslint/types",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/types",
+            "version": "3.10.1",
+            "size": 114473
+          }
+        },
+        {
+          "message": "\"resolve\" (eslint-config-next#eslint-plugin-react#resolve) not absorbed because top level dep is \"1.22.0\" and this is \"2.0.0-next.3\". This takes up an additional 109.1 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint-plugin-react#resolve",
+            "name": "resolve",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-plugin-react/node_modules/resolve",
+            "version": "2.0.0-next.3",
+            "size": 111764
+          }
+        },
+        {
+          "message": "\"doctrine\" (eslint-config-next#eslint#doctrine) not absorbed because top level dep is \"2.1.0\" and this is \"3.0.0\". This takes up an additional 103.9 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint#doctrine",
+            "name": "doctrine",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint/node_modules/doctrine",
+            "version": "3.0.0",
+            "size": 106364
+          }
+        },
+        {
+          "message": "\"eslint-scope\" (@typescript-eslint/eslint-plugin#@typescript-eslint/utils#eslint-scope) not absorbed because top level dep is \"7.1.1\" and this is \"5.1.1\". This takes up an additional 76.5 KiB.",
+          "meta": {
+            "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/utils#eslint-scope",
+            "name": "eslint-scope",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@typescript-eslint/utils/node_modules/eslint-scope",
+            "version": "5.1.1",
+            "size": 78356
+          }
+        },
+        {
+          "message": "\"semver\" (eslint-config-next#eslint-plugin-react#semver) not absorbed because top level dep is \"7.3.7\" and this is \"6.3.0\". This takes up an additional 65.5 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint-plugin-react#semver",
+            "name": "semver",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-plugin-react/node_modules/semver",
+            "version": "6.3.0",
+            "size": 67071
+          }
+        },
+        {
+          "message": "\"semver\" (jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#istanbul-lib-instrument#semver) not absorbed because top level dep is \"7.3.7\" and this is \"6.3.0\". This takes up an additional 65.5 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#istanbul-lib-instrument#semver",
+            "name": "semver",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/istanbul-lib-instrument/node_modules/semver",
+            "version": "6.3.0",
+            "size": 67071
+          }
+        },
+        {
+          "message": "\"semver\" (jest#@jest/core#@jest/reporters#istanbul-reports#istanbul-lib-report#make-dir#semver) not absorbed because top level dep is \"7.3.7\" and this is \"6.3.0\". This takes up an additional 65.5 KiB.",
+          "meta": {
+            "breadcrumb": "jest#@jest/core#@jest/reporters#istanbul-reports#istanbul-lib-report#make-dir#semver",
+            "name": "semver",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/make-dir/node_modules/semver",
+            "version": "6.3.0",
+            "size": 67071
+          }
+        },
+        {
+          "message": "\"semver\" (jest#jest-cli#jest-config#babel-jest#@babel/core#semver) not absorbed because top level dep is \"7.3.7\" and this is \"6.3.0\". This takes up an additional 65.5 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#semver",
+            "name": "semver",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@babel/core/node_modules/semver",
+            "version": "6.3.0",
+            "size": 67071
+          }
+        },
+        {
+          "message": "\"semver\" (jest#jest-cli#jest-config#babel-jest#@babel/core#@babel/helper-compilation-targets#semver) not absorbed because top level dep is \"7.3.7\" and this is \"6.3.0\". This takes up an additional 65.5 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#@babel/helper-compilation-targets#semver",
+            "name": "semver",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@babel/helper-compilation-targets/node_modules/semver",
+            "version": "6.3.0",
+            "size": 67071
+          }
+        },
+        {
+          "message": "\"commander\" (apollo-server-micro#apollo-server-core#@apollographql/graphql-playground-html#xss#commander) not absorbed because top level dep is \"8.3.0\" and this is \"2.20.3\". This takes up an additional 61.0 KiB.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#apollo-server-core#@apollographql/graphql-playground-html#xss#commander",
+            "name": "commander",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/xss/node_modules/commander",
+            "version": "2.20.3",
+            "size": 62442
+          }
+        },
+        {
+          "message": "\"glob\" (eslint-config-next#@next/eslint-plugin-next#glob) not absorbed because top level dep is \"7.2.0\" and this is \"7.1.7\". This takes up an additional 54.6 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#@next/eslint-plugin-next#glob",
+            "name": "glob",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@next/eslint-plugin-next/node_modules/glob",
+            "version": "7.1.7",
+            "size": 55910
+          }
+        },
+        {
+          "message": "\"glob\" (@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#glob) not absorbed because top level dep is \"7.2.0\" and this is \"8.0.1\". This takes up an additional 53.6 KiB.",
+          "meta": {
+            "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#glob",
+            "name": "glob",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/cacache/node_modules/glob",
+            "version": "8.0.1",
+            "size": 54890
+          }
+        },
+        {
+          "message": "\"glob\" (@npmcli/arborist#pacote#npm-packlist#glob) not absorbed because top level dep is \"7.2.0\" and this is \"8.0.1\". This takes up an additional 53.6 KiB.",
+          "meta": {
+            "breadcrumb": "@npmcli/arborist#pacote#npm-packlist#glob",
+            "name": "glob",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/npm-packlist/node_modules/glob",
+            "version": "8.0.1",
+            "size": 54890
+          }
+        },
+        {
+          "message": "\"glob\" (@npmcli/arborist#pacote#read-package-json#glob) not absorbed because top level dep is \"7.2.0\" and this is \"8.0.1\". This takes up an additional 53.6 KiB.",
+          "meta": {
+            "breadcrumb": "@npmcli/arborist#pacote#read-package-json#glob",
+            "name": "glob",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/read-package-json/node_modules/glob",
+            "version": "8.0.1",
+            "size": 54890
+          }
+        },
+        {
+          "message": "\"glob\" (@npmcli/arborist#@npmcli/map-workspaces#glob) not absorbed because top level dep is \"7.2.0\" and this is \"8.0.1\". This takes up an additional 53.6 KiB.",
+          "meta": {
+            "breadcrumb": "@npmcli/arborist#@npmcli/map-workspaces#glob",
+            "name": "glob",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@npmcli/map-workspaces/node_modules/glob",
+            "version": "8.0.1",
+            "size": 54890
+          }
+        },
+        {
+          "message": "\"debug\" (eslint-config-next#eslint-plugin-import#eslint-module-utils#debug) not absorbed because top level dep is \"4.3.4\" and this is \"3.2.7\". This takes up an additional 52.0 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-module-utils#debug",
+            "name": "debug",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-module-utils/node_modules/debug",
+            "version": "3.2.7",
+            "size": 53255
+          }
+        },
+        {
+          "message": "\"debug\" (eslint-config-next#eslint-plugin-import#eslint-import-resolver-node#debug) not absorbed because top level dep is \"4.3.4\" and this is \"3.2.7\". This takes up an additional 52.0 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-import-resolver-node#debug",
+            "name": "debug",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-plugin-import/node_modules/eslint-import-resolver-node/node_modules/debug",
+            "version": "3.2.7",
+            "size": 53255
+          }
+        },
+        {
+          "message": "\"debug\" (eslint-config-next#eslint-import-resolver-node#debug) not absorbed because top level dep is \"4.3.4\" and this is \"2.6.9\". This takes up an additional 50.0 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint-import-resolver-node#debug",
+            "name": "debug",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-import-resolver-node/node_modules/debug",
+            "version": "2.6.9",
+            "size": 51243
+          }
+        },
+        {
+          "message": "\"debug\" (eslint-config-next#eslint-plugin-import#debug) not absorbed because top level dep is \"4.3.4\" and this is \"2.6.9\". This takes up an additional 50.0 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint-plugin-import#debug",
+            "name": "debug",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-plugin-import/node_modules/debug",
+            "version": "2.6.9",
+            "size": 51243
+          }
+        },
+        {
+          "message": "\"optionator\" (jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator) not absorbed because top level dep is \"0.9.1\" and this is \"0.8.3\". This takes up an additional 48.9 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator",
+            "name": "optionator",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/escodegen/node_modules/optionator",
+            "version": "0.8.3",
+            "size": 50062
+          }
+        },
+        {
+          "message": "\"tslib\" (apollo-server-micro#apollo-server-core#graphql-tag#tslib) not absorbed because top level dep is \"2.3.1\" and this is \"2.4.0\". This takes up an additional 48.8 KiB.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#apollo-server-core#graphql-tag#tslib",
+            "name": "tslib",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/graphql-tag/node_modules/tslib",
+            "version": "2.4.0",
+            "size": 49968
+          }
+        },
+        {
+          "message": "\"tslib\" (lint-staged#listr2#rxjs#tslib) not absorbed because top level dep is \"2.3.1\" and this is \"2.4.0\". This takes up an additional 48.8 KiB.",
+          "meta": {
+            "breadcrumb": "lint-staged#listr2#rxjs#tslib",
+            "name": "tslib",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/rxjs/node_modules/tslib",
+            "version": "2.4.0",
+            "size": 49968
+          }
+        },
+        {
+          "message": "\"whatwg-url\" (apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-env#node-fetch#whatwg-url) not absorbed because top level dep is \"8.7.0\" and this is \"5.0.0\". This takes up an additional 48.7 KiB.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-env#node-fetch#whatwg-url",
+            "name": "whatwg-url",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/node-fetch/node_modules/whatwg-url",
+            "version": "5.0.0",
+            "size": 49886
+          }
+        },
+        {
+          "message": "\"cssom\" (jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#cssstyle#cssom) not absorbed because top level dep is \"0.4.4\" and this is \"0.3.8\". This takes up an additional 47.8 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#cssstyle#cssom",
+            "name": "cssom",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/cssstyle/node_modules/cssom",
+            "version": "0.3.8",
+            "size": 48996
+          }
+        },
+        {
+          "message": "\"emoji-regex\" (yargs#cliui#string-width#emoji-regex) not absorbed because top level dep is \"9.2.2\" and this is \"8.0.0\". This takes up an additional 47.1 KiB.",
+          "meta": {
+            "breadcrumb": "yargs#cliui#string-width#emoji-regex",
+            "name": "emoji-regex",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/string-width/node_modules/emoji-regex",
+            "version": "8.0.0",
+            "size": 48255
+          }
+        },
+        {
+          "message": "\"chalk\" (chalk) not absorbed because top level dep is \"4.1.2\" and this is \"5.0.1\". This takes up an additional 40.4 KiB.",
+          "meta": {
+            "breadcrumb": "chalk",
+            "name": "chalk",
+            "directory": "/Users/gcsapo/Documents/package-inspector/packages/pi-cli/node_modules/chalk",
+            "version": "5.0.1",
+            "size": 41336
+          }
+        },
+        {
+          "message": "\"globals\" (jest#jest-cli#jest-config#jest-circus#jest-snapshot#@babel/traverse#globals) not absorbed because top level dep is \"13.13.0\" and this is \"11.12.0\". This takes up an additional 38.8 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-snapshot#@babel/traverse#globals",
+            "name": "globals",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@babel/traverse/node_modules/globals",
+            "version": "11.12.0",
+            "size": 39779
+          }
+        },
+        {
+          "message": "\"prelude-ls\" (eslint-config-next#eslint#levn#prelude-ls) not absorbed because top level dep is \"1.1.2\" and this is \"1.2.1\". This takes up an additional 35.9 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint#levn#prelude-ls",
+            "name": "prelude-ls",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/levn/node_modules/prelude-ls",
+            "version": "1.2.1",
+            "size": 36741
+          }
+        },
+        {
+          "message": "\"prelude-ls\" (eslint-config-next#eslint#optionator#prelude-ls) not absorbed because top level dep is \"1.1.2\" and this is \"1.2.1\". This takes up an additional 35.9 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint#optionator#prelude-ls",
+            "name": "prelude-ls",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/optionator/node_modules/prelude-ls",
+            "version": "1.2.1",
+            "size": 36741
+          }
+        },
+        {
+          "message": "\"minimatch\" (@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#glob#minimatch) not absorbed because top level dep is \"3.1.2\" and this is \"5.0.1\". This takes up an additional 35.8 KiB.",
+          "meta": {
+            "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#glob#minimatch",
+            "name": "minimatch",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/cacache/node_modules/minimatch",
+            "version": "5.0.1",
+            "size": 36629
+          }
+        },
+        {
+          "message": "\"minimatch\" (@npmcli/arborist#pacote#npm-packlist#ignore-walk#minimatch) not absorbed because top level dep is \"3.1.2\" and this is \"5.0.1\". This takes up an additional 35.8 KiB.",
+          "meta": {
+            "breadcrumb": "@npmcli/arborist#pacote#npm-packlist#ignore-walk#minimatch",
+            "name": "minimatch",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/ignore-walk/node_modules/minimatch",
+            "version": "5.0.1",
+            "size": 36629
+          }
+        },
+        {
+          "message": "\"minimatch\" (@npmcli/arborist#pacote#npm-packlist#glob#minimatch) not absorbed because top level dep is \"3.1.2\" and this is \"5.0.1\". This takes up an additional 35.8 KiB.",
+          "meta": {
+            "breadcrumb": "@npmcli/arborist#pacote#npm-packlist#glob#minimatch",
+            "name": "minimatch",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/npm-packlist/node_modules/minimatch",
+            "version": "5.0.1",
+            "size": 36629
+          }
+        },
+        {
+          "message": "\"minimatch\" (@npmcli/arborist#pacote#read-package-json#glob#minimatch) not absorbed because top level dep is \"3.1.2\" and this is \"5.0.1\". This takes up an additional 35.8 KiB.",
+          "meta": {
+            "breadcrumb": "@npmcli/arborist#pacote#read-package-json#glob#minimatch",
+            "name": "minimatch",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/read-package-json/node_modules/minimatch",
+            "version": "5.0.1",
+            "size": 36629
+          }
+        },
+        {
+          "message": "\"minimatch\" (@npmcli/arborist#@npmcli/map-workspaces#minimatch) not absorbed because top level dep is \"3.1.2\" and this is \"5.0.1\". This takes up an additional 35.8 KiB.",
+          "meta": {
+            "breadcrumb": "@npmcli/arborist#@npmcli/map-workspaces#minimatch",
+            "name": "minimatch",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@npmcli/map-workspaces/node_modules/minimatch",
+            "version": "5.0.1",
+            "size": 36629
+          }
+        },
+        {
+          "message": "\"estraverse\" (@typescript-eslint/eslint-plugin#@typescript-eslint/utils#eslint-scope#estraverse) not absorbed because top level dep is \"5.3.0\" and this is \"4.3.0\". This takes up an additional 35.5 KiB.",
+          "meta": {
+            "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/utils#eslint-scope#estraverse",
+            "name": "estraverse",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@typescript-eslint/utils/node_modules/estraverse",
+            "version": "4.3.0",
+            "size": 36325
+          }
+        },
+        {
+          "message": "\"levn\" (jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator#levn) not absorbed because top level dep is \"0.4.1\" and this is \"0.3.0\". This takes up an additional 33.2 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator#levn",
+            "name": "levn",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/escodegen/node_modules/levn",
+            "version": "0.3.0",
+            "size": 34032
+          }
+        },
+        {
+          "message": "\"tslib\" (@typescript-eslint/eslint-plugin#tsutils#tslib) not absorbed because top level dep is \"2.3.1\" and this is \"1.14.1\". This takes up an additional 33.2 KiB.",
+          "meta": {
+            "breadcrumb": "@typescript-eslint/eslint-plugin#tsutils#tslib",
+            "name": "tslib",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/tsutils/node_modules/tslib",
+            "version": "1.14.1",
+            "size": 33965
+          }
+        },
+        {
+          "message": "\"retry\" (@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#promise-retry#retry) not absorbed because top level dep is \"0.13.1\" and this is \"0.12.0\". This takes up an additional 31.5 KiB.",
+          "meta": {
+            "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#promise-retry#retry",
+            "name": "retry",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/promise-retry/node_modules/retry",
+            "version": "0.12.0",
+            "size": 32210
+          }
+        },
+        {
+          "message": "\"safe-buffer\" (jest#@jest/core#@jest/reporters#v8-to-istanbul#convert-source-map#safe-buffer) not absorbed because top level dep is \"5.2.1\" and this is \"5.1.2\". This takes up an additional 30.9 KiB.",
+          "meta": {
+            "breadcrumb": "jest#@jest/core#@jest/reporters#v8-to-istanbul#convert-source-map#safe-buffer",
+            "name": "safe-buffer",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/convert-source-map/node_modules/safe-buffer",
+            "version": "5.1.2",
+            "size": 31686
+          }
+        },
+        {
+          "message": "\"depd\" (@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#agentkeepalive#depd) not absorbed because top level dep is \"1.1.1\" and this is \"1.1.2\". This takes up an additional 29.8 KiB.",
+          "meta": {
+            "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#agentkeepalive#depd",
+            "name": "depd",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/agentkeepalive/node_modules/depd",
+            "version": "1.1.2",
+            "size": 30483
+          }
+        },
+        {
+          "message": "\"@typescript-eslint/parser\" (eslint-config-next#@typescript-eslint/parser) not absorbed because top level dep is \"5.21.0\" and this is \"5.10.1\". This takes up an additional 28.4 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#@typescript-eslint/parser",
+            "name": "@typescript-eslint/parser",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-config-next/node_modules/@typescript-eslint/parser",
+            "version": "5.10.1",
+            "size": 29036
+          }
+        },
+        {
+          "message": "\"color-convert\" (jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#ansi-styles#color-convert) not absorbed because top level dep is \"2.0.1\" and this is \"1.9.3\". This takes up an additional 26.3 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#ansi-styles#color-convert",
+            "name": "color-convert",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@babel/highlight/node_modules/color-convert",
+            "version": "1.9.3",
+            "size": 26964
+          }
+        },
+        {
+          "message": "\"chalk\" (jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk) not absorbed because top level dep is \"4.1.2\" and this is \"2.4.2\". This takes up an additional 26.3 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk",
+            "name": "chalk",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@babel/highlight/node_modules/chalk",
+            "version": "2.4.2",
+            "size": 26924
+          }
+        },
+        {
+          "message": "\"eslint-visitor-keys\" (eslint-config-next#eslint#eslint-utils#eslint-visitor-keys) not absorbed because top level dep is \"3.3.0\" and this is \"2.1.0\". This takes up an additional 24.1 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint#eslint-utils#eslint-visitor-keys",
+            "name": "eslint-visitor-keys",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-utils/node_modules/eslint-visitor-keys",
+            "version": "2.1.0",
+            "size": 24680
+          }
+        },
+        {
+          "message": "\"react-is\" (eslint-config-next#eslint-plugin-react#prop-types#react-is) not absorbed because top level dep is \"17.0.2\" and this is \"16.13.1\". This takes up an additional 23.4 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint-plugin-react#prop-types#react-is",
+            "name": "react-is",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/prop-types/node_modules/react-is",
+            "version": "16.13.1",
+            "size": 23954
+          }
+        },
+        {
+          "message": "\"type-check\" (eslint-config-next#eslint#levn#type-check) not absorbed because top level dep is \"0.3.2\" and this is \"0.4.0\". This takes up an additional 20.7 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint#levn#type-check",
+            "name": "type-check",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/levn/node_modules/type-check",
+            "version": "0.4.0",
+            "size": 21167
+          }
+        },
+        {
+          "message": "\"type-check\" (eslint-config-next#eslint#optionator#type-check) not absorbed because top level dep is \"0.3.2\" and this is \"0.4.0\". This takes up an additional 20.7 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint#optionator#type-check",
+            "name": "type-check",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/optionator/node_modules/type-check",
+            "version": "0.4.0",
+            "size": 21167
+          }
+        },
+        {
+          "message": "\"webidl-conversions\" (jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#domexception#webidl-conversions) not absorbed because top level dep is \"6.1.0\" and this is \"5.0.0\". This takes up an additional 19.5 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#domexception#webidl-conversions",
+            "name": "webidl-conversions",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/domexception/node_modules/webidl-conversions",
+            "version": "5.0.0",
+            "size": 19951
+          }
+        },
+        {
+          "message": "\"http-proxy-agent\" (jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#http-proxy-agent) not absorbed because top level dep is \"5.0.0\" and this is \"4.0.1\". This takes up an additional 16.7 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#http-proxy-agent",
+            "name": "http-proxy-agent",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jsdom/node_modules/http-proxy-agent",
+            "version": "4.0.1",
+            "size": 17062
+          }
+        },
+        {
+          "message": "\"@typescript-eslint/visitor-keys\" (@typescript-eslint/eslint-plugin#@typescript-eslint/scope-manager#@typescript-eslint/visitor-keys) not absorbed because top level dep is \"5.10.1\" and this is \"5.21.0\". This takes up an additional 16.5 KiB.",
+          "meta": {
+            "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/scope-manager#@typescript-eslint/visitor-keys",
+            "name": "@typescript-eslint/visitor-keys",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@typescript-eslint/scope-manager/node_modules/@typescript-eslint/visitor-keys",
+            "version": "5.21.0",
+            "size": 16870
+          }
+        },
+        {
+          "message": "\"@typescript-eslint/visitor-keys\" (@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#@typescript-eslint/visitor-keys) not absorbed because top level dep is \"5.10.1\" and this is \"5.21.0\". This takes up an additional 16.5 KiB.",
+          "meta": {
+            "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#@typescript-eslint/visitor-keys",
+            "name": "@typescript-eslint/visitor-keys",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/visitor-keys",
+            "version": "5.21.0",
+            "size": 16870
+          }
+        },
+        {
+          "message": "\"lru-cache\" (apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-caching#lru-cache) not absorbed because top level dep is \"7.8.1\" and this is \"6.0.0\". This takes up an additional 15.3 KiB.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-caching#lru-cache",
+            "name": "lru-cache",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/apollo-server-caching/node_modules/lru-cache",
+            "version": "6.0.0",
+            "size": 15643
+          }
+        },
+        {
+          "message": "\"lru-cache\" (apollo-server-micro#apollo-server-core#lru-cache) not absorbed because top level dep is \"7.8.1\" and this is \"6.0.0\". This takes up an additional 15.3 KiB.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#apollo-server-core#lru-cache",
+            "name": "lru-cache",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/apollo-server-core/node_modules/lru-cache",
+            "version": "6.0.0",
+            "size": 15643
+          }
+        },
+        {
+          "message": "\"lru-cache\" (@npmcli/arborist#pacote#npm-pick-manifest#npm-package-arg#validate-npm-package-name#builtins#semver#lru-cache) not absorbed because top level dep is \"7.8.1\" and this is \"6.0.0\". This takes up an additional 15.3 KiB.",
+          "meta": {
+            "breadcrumb": "@npmcli/arborist#pacote#npm-pick-manifest#npm-package-arg#validate-npm-package-name#builtins#semver#lru-cache",
+            "name": "lru-cache",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/semver/node_modules/lru-cache",
+            "version": "6.0.0",
+            "size": 15643
+          }
+        },
+        {
+          "message": "\"ansi-styles\" (lint-staged#cli-truncate#slice-ansi#ansi-styles) not absorbed because top level dep is \"4.3.0\" and this is \"6.1.0\". This takes up an additional 15.2 KiB.",
+          "meta": {
+            "breadcrumb": "lint-staged#cli-truncate#slice-ansi#ansi-styles",
+            "name": "ansi-styles",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/slice-ansi/node_modules/ansi-styles",
+            "version": "6.1.0",
+            "size": 15535
+          }
+        },
+        {
+          "message": "\"ansi-styles\" (jest#jest-cli#jest-config#jest-circus#pretty-format#ansi-styles) not absorbed because top level dep is \"4.3.0\" and this is \"5.2.0\". This takes up an additional 13.3 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#pretty-format#ansi-styles",
+            "name": "ansi-styles",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/pretty-format/node_modules/ansi-styles",
+            "version": "5.2.0",
+            "size": 13596
+          }
+        },
+        {
+          "message": "\"write-file-atomic\" (jest#jest-cli#jest-config#babel-jest#@jest/transform#write-file-atomic) not absorbed because top level dep is \"4.0.1\" and this is \"3.0.3\". This takes up an additional 12.5 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@jest/transform#write-file-atomic",
+            "name": "write-file-atomic",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@jest/transform/node_modules/write-file-atomic",
+            "version": "3.0.3",
+            "size": 12787
+          }
+        },
+        {
+          "message": "\"webidl-conversions\" (apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-env#node-fetch#whatwg-url#webidl-conversions) not absorbed because top level dep is \"6.1.0\" and this is \"3.0.1\". This takes up an additional 12.1 KiB.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-env#node-fetch#whatwg-url#webidl-conversions",
+            "name": "webidl-conversions",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/node-fetch/node_modules/webidl-conversions",
+            "version": "3.0.1",
+            "size": 12370
+          }
+        },
+        {
+          "message": "\"glob-parent\" (@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#fast-glob#glob-parent) not absorbed because top level dep is \"6.0.2\" and this is \"5.1.2\". This takes up an additional 11.8 KiB.",
+          "meta": {
+            "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#fast-glob#glob-parent",
+            "name": "glob-parent",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/fast-glob/node_modules/glob-parent",
+            "version": "5.1.2",
+            "size": 12134
+          }
+        },
+        {
+          "message": "\"brace-expansion\" (@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#glob#minimatch#brace-expansion) not absorbed because top level dep is \"1.1.11\" and this is \"2.0.1\". This takes up an additional 11.2 KiB.",
+          "meta": {
+            "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#glob#minimatch#brace-expansion",
+            "name": "brace-expansion",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/cacache/node_modules/brace-expansion",
+            "version": "2.0.1",
+            "size": 11486
+          }
+        },
+        {
+          "message": "\"brace-expansion\" (@npmcli/arborist#pacote#npm-packlist#ignore-walk#minimatch#brace-expansion) not absorbed because top level dep is \"1.1.11\" and this is \"2.0.1\". This takes up an additional 11.2 KiB.",
+          "meta": {
+            "breadcrumb": "@npmcli/arborist#pacote#npm-packlist#ignore-walk#minimatch#brace-expansion",
+            "name": "brace-expansion",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/ignore-walk/node_modules/brace-expansion",
+            "version": "2.0.1",
+            "size": 11486
+          }
+        },
+        {
+          "message": "\"brace-expansion\" (@npmcli/arborist#pacote#npm-packlist#glob#minimatch#brace-expansion) not absorbed because top level dep is \"1.1.11\" and this is \"2.0.1\". This takes up an additional 11.2 KiB.",
+          "meta": {
+            "breadcrumb": "@npmcli/arborist#pacote#npm-packlist#glob#minimatch#brace-expansion",
+            "name": "brace-expansion",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/npm-packlist/node_modules/brace-expansion",
+            "version": "2.0.1",
+            "size": 11486
+          }
+        },
+        {
+          "message": "\"brace-expansion\" (@npmcli/arborist#pacote#read-package-json#glob#minimatch#brace-expansion) not absorbed because top level dep is \"1.1.11\" and this is \"2.0.1\". This takes up an additional 11.2 KiB.",
+          "meta": {
+            "breadcrumb": "@npmcli/arborist#pacote#read-package-json#glob#minimatch#brace-expansion",
+            "name": "brace-expansion",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/read-package-json/node_modules/brace-expansion",
+            "version": "2.0.1",
+            "size": 11486
+          }
+        },
+        {
+          "message": "\"brace-expansion\" (@npmcli/arborist#@npmcli/map-workspaces#minimatch#brace-expansion) not absorbed because top level dep is \"1.1.11\" and this is \"2.0.1\". This takes up an additional 11.2 KiB.",
+          "meta": {
+            "breadcrumb": "@npmcli/arborist#@npmcli/map-workspaces#minimatch#brace-expansion",
+            "name": "brace-expansion",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@npmcli/map-workspaces/node_modules/brace-expansion",
+            "version": "2.0.1",
+            "size": 11486
+          }
+        },
+        {
+          "message": "\"supports-color\" (lint-staged#supports-color) not absorbed because top level dep is \"7.2.0\" and this is \"9.2.2\". This takes up an additional 10.2 KiB.",
+          "meta": {
+            "breadcrumb": "lint-staged#supports-color",
+            "name": "supports-color",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/lint-staged/node_modules/supports-color",
+            "version": "9.2.2",
+            "size": 10408
+          }
+        },
+        {
+          "message": "\"cli-truncate\" (lint-staged#listr2#cli-truncate) not absorbed because top level dep is \"3.1.0\" and this is \"2.1.0\". This takes up an additional 10.1 KiB.",
+          "meta": {
+            "breadcrumb": "lint-staged#listr2#cli-truncate",
+            "name": "cli-truncate",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/listr2/node_modules/cli-truncate",
+            "version": "2.1.0",
+            "size": 10357
+          }
+        },
+        {
+          "message": "\"wrap-ansi\" (lint-staged#listr2#log-update#wrap-ansi) not absorbed because top level dep is \"7.0.0\" and this is \"6.2.0\". This takes up an additional 9.3 KiB.",
+          "meta": {
+            "breadcrumb": "lint-staged#listr2#log-update#wrap-ansi",
+            "name": "wrap-ansi",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/log-update/node_modules/wrap-ansi",
+            "version": "6.2.0",
+            "size": 9500
+          }
+        },
+        {
+          "message": "\"ansi-styles\" (jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#ansi-styles) not absorbed because top level dep is \"4.3.0\" and this is \"3.2.1\". This takes up an additional 9.2 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#ansi-styles",
+            "name": "ansi-styles",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@babel/highlight/node_modules/ansi-styles",
+            "version": "3.2.1",
+            "size": 9371
+          }
+        },
+        {
+          "message": "\"color-name\" (jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#ansi-styles#color-convert#color-name) not absorbed because top level dep is \"1.1.4\" and this is \"1.1.3\". This takes up an additional 9.1 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#ansi-styles#color-convert#color-name",
+            "name": "color-name",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@babel/highlight/node_modules/color-name",
+            "version": "1.1.3",
+            "size": 9360
+          }
+        },
+        {
+          "message": "\"supports-color\" (jest#jest-cli#jest-config#jest-resolve#jest-haste-map#jest-worker#supports-color) not absorbed because top level dep is \"7.2.0\" and this is \"8.1.1\". This takes up an additional 8.3 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-resolve#jest-haste-map#jest-worker#supports-color",
+            "name": "supports-color",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-worker/node_modules/supports-color",
+            "version": "8.1.1",
+            "size": 8452
+          }
+        },
+        {
+          "message": "\"camelcase\" (jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@istanbuljs/load-nyc-config#camelcase) not absorbed because top level dep is \"6.3.0\" and this is \"5.3.1\". This takes up an additional 7.3 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@istanbuljs/load-nyc-config#camelcase",
+            "name": "camelcase",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase",
+            "version": "5.3.1",
+            "size": 7447
+          }
+        },
+        {
+          "message": "\"ms\" (@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#agentkeepalive#debug#ms) not absorbed because top level dep is \"2.1.3\" and this is \"2.1.2\". This takes up an additional 6.7 KiB.",
+          "meta": {
+            "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#agentkeepalive#debug#ms",
+            "name": "ms",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/debug/node_modules/ms",
+            "version": "2.1.2",
+            "size": 6842
+          }
+        },
+        {
+          "message": "\"supports-color\" (jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#supports-color) not absorbed because top level dep is \"7.2.0\" and this is \"5.5.0\". This takes up an additional 6.5 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#supports-color",
+            "name": "supports-color",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@babel/highlight/node_modules/supports-color",
+            "version": "5.5.0",
+            "size": 6630
+          }
+        },
+        {
+          "message": "\"slice-ansi\" (lint-staged#listr2#log-update#slice-ansi) not absorbed because top level dep is \"5.0.0\" and this is \"4.0.0\". This takes up an additional 6.3 KiB.",
+          "meta": {
+            "breadcrumb": "lint-staged#listr2#log-update#slice-ansi",
+            "name": "slice-ansi",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/log-update/node_modules/slice-ansi",
+            "version": "4.0.0",
+            "size": 6434
+          }
+        },
+        {
+          "message": "\"ms\" (eslint-config-next#eslint-import-resolver-node#debug#ms) not absorbed because top level dep is \"2.1.3\" and this is \"2.0.0\". This takes up an additional 6.1 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint-import-resolver-node#debug#ms",
+            "name": "ms",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-import-resolver-node/node_modules/ms",
+            "version": "2.0.0",
+            "size": 6266
+          }
+        },
+        {
+          "message": "\"ms\" (eslint-config-next#eslint-plugin-import#debug#ms) not absorbed because top level dep is \"2.1.3\" and this is \"2.0.0\". This takes up an additional 6.1 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint-plugin-import#debug#ms",
+            "name": "ms",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-plugin-import/node_modules/ms",
+            "version": "2.0.0",
+            "size": 6266
+          }
+        },
+        {
+          "message": "\"slice-ansi\" (lint-staged#listr2#cli-truncate#slice-ansi) not absorbed because top level dep is \"5.0.0\" and this is \"3.0.0\". This takes up an additional 6.1 KiB.",
+          "meta": {
+            "breadcrumb": "lint-staged#listr2#cli-truncate#slice-ansi",
+            "name": "slice-ansi",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/listr2/node_modules/slice-ansi",
+            "version": "3.0.0",
+            "size": 6204
+          }
+        },
+        {
+          "message": "\"is-stream\" (jest#@jest/core#jest-changed-files#execa#is-stream) not absorbed because top level dep is \"1.1.0\" and this is \"2.0.1\". This takes up an additional 5.8 KiB.",
+          "meta": {
+            "breadcrumb": "jest#@jest/core#jest-changed-files#execa#is-stream",
+            "name": "is-stream",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/execa/node_modules/is-stream",
+            "version": "2.0.1",
+            "size": 5927
+          }
+        },
+        {
+          "message": "\"string-width\" (lint-staged#cli-truncate#string-width) not absorbed because top level dep is \"4.2.3\" and this is \"5.1.2\". This takes up an additional 5.6 KiB.",
+          "meta": {
+            "breadcrumb": "lint-staged#cli-truncate#string-width",
+            "name": "string-width",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/cli-truncate/node_modules/string-width",
+            "version": "5.1.2",
+            "size": 5781
+          }
+        },
+        {
+          "message": "\"ansi-regex\" (lint-staged#cli-truncate#string-width#strip-ansi#ansi-regex) not absorbed because top level dep is \"5.0.1\" and this is \"6.0.1\". This takes up an additional 5.5 KiB.",
+          "meta": {
+            "breadcrumb": "lint-staged#cli-truncate#string-width#strip-ansi#ansi-regex",
+            "name": "ansi-regex",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/cli-truncate/node_modules/ansi-regex",
+            "version": "6.0.1",
+            "size": 5667
+          }
+        },
+        {
+          "message": "\"eslint-import-resolver-node\" (eslint-config-next#eslint-plugin-import#eslint-import-resolver-node) not absorbed because top level dep is \"0.3.4\" and this is \"0.3.6\". This takes up an additional 5.2 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-import-resolver-node",
+            "name": "eslint-import-resolver-node",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-plugin-import/node_modules/eslint-import-resolver-node",
+            "version": "0.3.6",
+            "size": 5373
+          }
+        },
+        {
+          "message": "\"is-fullwidth-code-point\" (lint-staged#cli-truncate#slice-ansi#is-fullwidth-code-point) not absorbed because top level dep is \"3.0.0\" and this is \"4.0.0\". This takes up an additional 5.1 KiB.",
+          "meta": {
+            "breadcrumb": "lint-staged#cli-truncate#slice-ansi#is-fullwidth-code-point",
+            "name": "is-fullwidth-code-point",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/slice-ansi/node_modules/is-fullwidth-code-point",
+            "version": "4.0.0",
+            "size": 5189
+          }
+        },
+        {
+          "message": "\"p-locate\" (eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path#p-locate) not absorbed because top level dep is \"4.1.0\" and this is \"2.0.0\". This takes up an additional 4.9 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path#p-locate",
+            "name": "p-locate",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-module-utils/node_modules/p-locate",
+            "version": "2.0.0",
+            "size": 5053
+          }
+        },
+        {
+          "message": "\"find-up\" (eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up) not absorbed because top level dep is \"4.1.0\" and this is \"2.1.0\". This takes up an additional 4.7 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up",
+            "name": "find-up",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-module-utils/node_modules/find-up",
+            "version": "2.1.0",
+            "size": 4803
+          }
+        },
+        {
+          "message": "\"resolve-from\" (eslint-config-next#eslint#import-fresh#resolve-from) not absorbed because top level dep is \"5.0.0\" and this is \"4.0.0\". This takes up an additional 4.5 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint#import-fresh#resolve-from",
+            "name": "resolve-from",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/import-fresh/node_modules/resolve-from",
+            "version": "4.0.0",
+            "size": 4641
+          }
+        },
+        {
+          "message": "\"strip-ansi\" (lint-staged#cli-truncate#string-width#strip-ansi) not absorbed because top level dep is \"6.0.1\" and this is \"7.0.1\". This takes up an additional 4.0 KiB.",
+          "meta": {
+            "breadcrumb": "lint-staged#cli-truncate#string-width#strip-ansi",
+            "name": "strip-ansi",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/cli-truncate/node_modules/strip-ansi",
+            "version": "7.0.1",
+            "size": 4090
+          }
+        },
+        {
+          "message": "\"@tootallnate/once\" (jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#http-proxy-agent#@tootallnate/once) not absorbed because top level dep is \"2.0.0\" and this is \"1.1.2\". This takes up an additional 4.0 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#http-proxy-agent#@tootallnate/once",
+            "name": "@tootallnate/once",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jsdom/node_modules/@tootallnate/once",
+            "version": "1.1.2",
+            "size": 4085
+          }
+        },
+        {
+          "message": "\"locate-path\" (eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path) not absorbed because top level dep is \"5.0.0\" and this is \"2.0.0\". This takes up an additional 3.9 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path",
+            "name": "locate-path",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-module-utils/node_modules/locate-path",
+            "version": "2.0.0",
+            "size": 3969
+          }
+        },
+        {
+          "message": "\"p-limit\" (eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path#p-locate#p-limit) not absorbed because top level dep is \"2.3.0\" and this is \"1.3.0\". This takes up an additional 3.9 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path#p-locate#p-limit",
+            "name": "p-limit",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-module-utils/node_modules/p-limit",
+            "version": "1.3.0",
+            "size": 3963
+          }
+        },
+        {
+          "message": "\"strip-bom\" (jest#jest-cli#jest-config#jest-circus#jest-runtime#strip-bom) not absorbed because top level dep is \"3.0.0\" and this is \"4.0.0\". This takes up an additional 3.8 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-runtime#strip-bom",
+            "name": "strip-bom",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-runtime/node_modules/strip-bom",
+            "version": "4.0.0",
+            "size": 3910
+          }
+        },
+        {
+          "message": "\"inherits\" (apollo-server-micro#micro#raw-body#http-errors#inherits) not absorbed because top level dep is \"2.0.4\" and this is \"2.0.3\". This takes up an additional 3.7 KiB.",
+          "meta": {
+            "breadcrumb": "apollo-server-micro#micro#raw-body#http-errors#inherits",
+            "name": "inherits",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/http-errors/node_modules/inherits",
+            "version": "2.0.3",
+            "size": 3824
+          }
+        },
+        {
+          "message": "\"path-exists\" (eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path#path-exists) not absorbed because top level dep is \"4.0.0\" and this is \"3.0.0\". This takes up an additional 3.2 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path#path-exists",
+            "name": "path-exists",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-module-utils/node_modules/path-exists",
+            "version": "3.0.0",
+            "size": 3316
+          }
+        },
+        {
+          "message": "\"escape-string-regexp\" (jest#jest-cli#jest-config#jest-circus#stack-utils#escape-string-regexp) not absorbed because top level dep is \"4.0.0\" and this is \"2.0.0\". This takes up an additional 3.2 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#stack-utils#escape-string-regexp",
+            "name": "escape-string-regexp",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/stack-utils/node_modules/escape-string-regexp",
+            "version": "2.0.0",
+            "size": 3259
+          }
+        },
+        {
+          "message": "\"has-flag\" (jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#supports-color#has-flag) not absorbed because top level dep is \"4.0.0\" and this is \"3.0.0\". This takes up an additional 3.1 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#supports-color#has-flag",
+            "name": "has-flag",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@babel/highlight/node_modules/has-flag",
+            "version": "3.0.0",
+            "size": 3125
+          }
+        },
+        {
+          "message": "\"p-try\" (eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path#p-locate#p-limit#p-try) not absorbed because top level dep is \"2.2.0\" and this is \"1.0.0\". This takes up an additional 2.7 KiB.",
+          "meta": {
+            "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path#p-locate#p-limit#p-try",
+            "name": "p-try",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-module-utils/node_modules/p-try",
+            "version": "1.0.0",
+            "size": 2798
+          }
+        },
+        {
+          "message": "\"escape-string-regexp\" (jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#escape-string-regexp) not absorbed because top level dep is \"4.0.0\" and this is \"1.0.5\". This takes up an additional 2.6 KiB.",
+          "meta": {
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#escape-string-regexp",
+            "name": "escape-string-regexp",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@babel/highlight/node_modules/escape-string-regexp",
+            "version": "1.0.5",
+            "size": 2688
+          }
+        }
+      ]
+    },
+    {
+      "id": "nestedDependencyFreshness",
+      "name": "Nested Dependency Freshness",
+      "message": "Out of the total 772 sub packages currently installed; 218 major versions out of date (28.24%), 32 minor versions out of date (4.15%), 9 patch versions out of date (1.17%)",
+      "actions": [
+        {
+          "message": "\"acorn-walk@7.2.0\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#acorn-globals#acorn-walk\", the latest is 8.2.0. This is a major version out of date.",
+          "meta": {
+            "name": "acorn-walk",
+            "version": "7.2.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/acorn-walk",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#acorn-globals#acorn-walk"
+          }
+        },
+        {
+          "message": "\"aggregate-error@3.1.0\" is required at \"@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#p-map#aggregate-error\", the latest is 4.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "aggregate-error",
+            "version": "3.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/aggregate-error",
+            "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#p-map#aggregate-error"
+          }
+        },
+        {
+          "message": "\"ansi-escapes@4.3.2\" is required at \"jest#@jest/core#jest-watcher#ansi-escapes\", the latest is 5.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "ansi-escapes",
+            "version": "4.3.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/ansi-escapes",
+            "breadcrumb": "jest#@jest/core#jest-watcher#ansi-escapes"
+          }
+        },
+        {
+          "message": "\"ansi-regex@5.0.1\" is required at \"jest#jest-cli#jest-config#jest-circus#pretty-format#ansi-regex\", the latest is 6.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "ansi-regex",
+            "version": "5.0.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/ansi-regex",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#pretty-format#ansi-regex"
+          }
+        },
+        {
+          "message": "\"ajv@6.12.6\" is required at \"eslint-config-next#eslint#ajv\", the latest is 8.11.0. This is a major version out of date.",
+          "meta": {
+            "name": "ajv",
+            "version": "6.12.6",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/ajv",
+            "breadcrumb": "eslint-config-next#eslint#ajv"
+          }
+        },
+        {
+          "message": "\"ansi-styles@4.3.0\" is required at \"jest#jest-cli#jest-config#babel-jest#chalk#ansi-styles\", the latest is 6.1.0. This is a major version out of date.",
+          "meta": {
+            "name": "ansi-styles",
+            "version": "4.3.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/ansi-styles",
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#chalk#ansi-styles"
+          }
+        },
+        {
+          "message": "\"arg@4.1.0\" is required at \"apollo-server-micro#micro#arg\", the latest is 5.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "arg",
+            "version": "4.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/arg",
+            "breadcrumb": "apollo-server-micro#micro#arg"
+          }
+        },
+        {
+          "message": "\"aria-query@4.2.2\" is required at \"eslint-config-next#eslint-plugin-jsx-a11y#aria-query\", the latest is 5.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "aria-query",
+            "version": "4.2.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/aria-query",
+            "breadcrumb": "eslint-config-next#eslint-plugin-jsx-a11y#aria-query"
+          }
+        },
+        {
+          "message": "\"axobject-query@2.2.0\" is required at \"eslint-config-next#eslint-plugin-jsx-a11y#axobject-query\", the latest is 3.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "axobject-query",
+            "version": "2.2.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/axobject-query",
+            "breadcrumb": "eslint-config-next#eslint-plugin-jsx-a11y#axobject-query"
+          }
+        },
+        {
+          "message": "\"babel-jest@27.5.1\" is required at \"jest#jest-cli#jest-config#babel-jest\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "babel-jest",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/babel-jest",
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest"
+          }
+        },
+        {
+          "message": "\"array-union@2.1.0\" is required at \"@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#array-union\", the latest is 3.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "array-union",
+            "version": "2.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/array-union",
+            "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#array-union"
+          }
+        },
+        {
+          "message": "\"babel-plugin-jest-hoist@27.5.1\" is required at \"jest#jest-cli#jest-config#babel-jest#babel-preset-jest#babel-plugin-jest-hoist\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "babel-plugin-jest-hoist",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/babel-plugin-jest-hoist",
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-preset-jest#babel-plugin-jest-hoist"
+          }
+        },
+        {
+          "message": "\"balanced-match@1.0.2\" is required at \"eslint-config-next#eslint#minimatch#brace-expansion#balanced-match\", the latest is 2.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "balanced-match",
+            "version": "1.0.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/balanced-match",
+            "breadcrumb": "eslint-config-next#eslint#minimatch#brace-expansion#balanced-match"
+          }
+        },
+        {
+          "message": "\"babel-preset-jest@27.5.1\" is required at \"jest#jest-cli#jest-config#babel-jest#babel-preset-jest\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "babel-preset-jest",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/babel-preset-jest",
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-preset-jest"
+          }
+        },
+        {
+          "message": "\"bl@4.1.0\" is required at \"ora#bl\", the latest is 5.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "bl",
+            "version": "4.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/bl",
+            "breadcrumb": "ora#bl"
+          }
+        },
+        {
+          "message": "\"brace-expansion@1.1.11\" is required at \"eslint-config-next#eslint#minimatch#brace-expansion\", the latest is 2.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "brace-expansion",
+            "version": "1.1.11",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/brace-expansion",
+            "breadcrumb": "eslint-config-next#eslint#minimatch#brace-expansion"
+          }
+        },
+        {
+          "message": "\"buffer@5.7.1\" is required at \"ora#bl#buffer\", the latest is 6.0.3. This is a major version out of date.",
+          "meta": {
+            "name": "buffer",
+            "version": "5.7.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/buffer",
+            "breadcrumb": "ora#bl#buffer"
+          }
+        },
+        {
+          "message": "\"callsites@3.1.0\" is required at \"eslint-config-next#eslint#import-fresh#parent-module#callsites\", the latest is 4.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "callsites",
+            "version": "3.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/callsites",
+            "breadcrumb": "eslint-config-next#eslint#import-fresh#parent-module#callsites"
+          }
+        },
+        {
+          "message": "\"chalk@4.1.2\" is required at \"jest#jest-cli#jest-config#babel-jest#chalk\", the latest is 5.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "chalk",
+            "version": "4.1.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/chalk",
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#chalk"
+          }
+        },
+        {
+          "message": "\"char-regex@1.0.2\" is required at \"jest#@jest/core#jest-watcher#string-length#char-regex\", the latest is 2.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "char-regex",
+            "version": "1.0.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/char-regex",
+            "breadcrumb": "jest#@jest/core#jest-watcher#string-length#char-regex"
+          }
+        },
+        {
+          "message": "\"clean-stack@2.2.0\" is required at \"@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#p-map#aggregate-error#clean-stack\", the latest is 4.1.0. This is a major version out of date.",
+          "meta": {
+            "name": "clean-stack",
+            "version": "2.2.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/clean-stack",
+            "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#p-map#aggregate-error#clean-stack"
+          }
+        },
+        {
+          "message": "\"cli-cursor@3.1.0\" is required at \"lint-staged#listr2#log-update#cli-cursor\", the latest is 4.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "cli-cursor",
+            "version": "3.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/cli-cursor",
+            "breadcrumb": "lint-staged#listr2#log-update#cli-cursor"
+          }
+        },
+        {
+          "message": "\"clone@1.0.4\" is required at \"ora#wcwidth#defaults#clone\", the latest is 2.1.2. This is a major version out of date.",
+          "meta": {
+            "name": "clone",
+            "version": "1.0.4",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/clone",
+            "breadcrumb": "ora#wcwidth#defaults#clone"
+          }
+        },
+        {
+          "message": "\"commander@8.3.0\" is required at \"lint-staged#commander\", the latest is 9.2.0. This is a major version out of date.",
+          "meta": {
+            "name": "commander",
+            "version": "8.3.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/commander",
+            "breadcrumb": "lint-staged#commander"
+          }
+        },
+        {
+          "message": "\"data-urls@2.0.0\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#data-urls\", the latest is 3.0.2. This is a major version out of date.",
+          "meta": {
+            "name": "data-urls",
+            "version": "2.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/data-urls",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#data-urls"
+          }
+        },
+        {
+          "message": "\"depd@1.1.1\" is required at \"apollo-server-micro#micro#raw-body#http-errors#depd\", the latest is 2.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "depd",
+            "version": "1.1.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/depd",
+            "breadcrumb": "apollo-server-micro#micro#raw-body#http-errors#depd"
+          }
+        },
+        {
+          "message": "\"diff-sequences@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-circus#expect#jest-matcher-utils#jest-diff#diff-sequences\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "diff-sequences",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/diff-sequences",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-matcher-utils#jest-diff#diff-sequences"
+          }
+        },
+        {
+          "message": "\"detect-newline@3.1.0\" is required at \"jest#jest-cli#jest-config#jest-runner#jest-docblock#detect-newline\", the latest is 4.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "detect-newline",
+            "version": "3.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/detect-newline",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-runner#jest-docblock#detect-newline"
+          }
+        },
+        {
+          "message": "\"doctrine@2.1.0\" is required at \"eslint-config-next#eslint-plugin-import#doctrine\", the latest is 3.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "doctrine",
+            "version": "2.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/doctrine",
+            "breadcrumb": "eslint-config-next#eslint-plugin-import#doctrine"
+          }
+        },
+        {
+          "message": "\"domexception@2.0.1\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#domexception\", the latest is 4.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "domexception",
+            "version": "2.0.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/domexception",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#domexception"
+          }
+        },
+        {
+          "message": "\"emoji-regex@9.2.2\" is required at \"eslint-config-next#eslint-plugin-jsx-a11y#emoji-regex\", the latest is 10.1.0. This is a major version out of date.",
+          "meta": {
+            "name": "emoji-regex",
+            "version": "9.2.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/emoji-regex",
+            "breadcrumb": "eslint-config-next#eslint-plugin-jsx-a11y#emoji-regex"
+          }
+        },
+        {
+          "message": "\"err-code@2.0.3\" is required at \"@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#promise-retry#err-code\", the latest is 3.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "err-code",
+            "version": "2.0.3",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/err-code",
+            "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#promise-retry#err-code"
+          }
+        },
+        {
+          "message": "\"env-paths@2.2.1\" is required at \"@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#env-paths\", the latest is 3.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "env-paths",
+            "version": "2.2.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/env-paths",
+            "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#env-paths"
+          }
+        },
+        {
+          "message": "\"escape-string-regexp@4.0.0\" is required at \"eslint-config-next#eslint#escape-string-regexp\", the latest is 5.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "escape-string-regexp",
+            "version": "4.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/escape-string-regexp",
+            "breadcrumb": "eslint-config-next#eslint#escape-string-regexp"
+          }
+        },
+        {
+          "message": "\"execa@5.1.1\" is required at \"jest#@jest/core#jest-changed-files#execa\", the latest is 6.1.0. This is a major version out of date.",
+          "meta": {
+            "name": "execa",
+            "version": "5.1.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/execa",
+            "breadcrumb": "jest#@jest/core#jest-changed-files#execa"
+          }
+        },
+        {
+          "message": "\"expect@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-circus#expect\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "expect",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/expect",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect"
+          }
+        },
+        {
+          "message": "\"fast-levenshtein@2.0.6\" is required at \"eslint-config-next#eslint#optionator#fast-levenshtein\", the latest is 3.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "fast-levenshtein",
+            "version": "2.0.6",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/fast-levenshtein",
+            "breadcrumb": "eslint-config-next#eslint#optionator#fast-levenshtein"
+          }
+        },
+        {
+          "message": "\"find-up@4.1.0\" is required at \"jest#import-local#pkg-dir#find-up\", the latest is 6.3.0. This is a major version out of date.",
+          "meta": {
+            "name": "find-up",
+            "version": "4.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/find-up",
+            "breadcrumb": "jest#import-local#pkg-dir#find-up"
+          }
+        },
+        {
+          "message": "\"form-data@3.0.1\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#form-data\", the latest is 4.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "form-data",
+            "version": "3.0.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/form-data",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#form-data"
+          }
+        },
+        {
+          "message": "\"glob@7.2.0\" is required at \"eslint-config-next#eslint-import-resolver-typescript#glob\", the latest is 8.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "glob",
+            "version": "7.2.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/glob",
+            "breadcrumb": "eslint-config-next#eslint-import-resolver-typescript#glob"
+          }
+        },
+        {
+          "message": "\"globby@11.1.0\" is required at \"@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby\", the latest is 13.1.1. This is a major version out of date.",
+          "meta": {
+            "name": "globby",
+            "version": "11.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/globby",
+            "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby"
+          }
+        },
+        {
+          "message": "\"has-flag@4.0.0\" is required at \"jest#jest-cli#jest-config#babel-jest#chalk#supports-color#has-flag\", the latest is 5.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "has-flag",
+            "version": "4.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/has-flag",
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#chalk#supports-color#has-flag"
+          }
+        },
+        {
+          "message": "\"html-encoding-sniffer@2.0.1\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#html-encoding-sniffer\", the latest is 3.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "html-encoding-sniffer",
+            "version": "2.0.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/html-encoding-sniffer",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#html-encoding-sniffer"
+          }
+        },
+        {
+          "message": "\"html-escaper@2.0.2\" is required at \"jest#@jest/core#@jest/reporters#istanbul-reports#html-escaper\", the latest is 3.0.3. This is a major version out of date.",
+          "meta": {
+            "name": "html-escaper",
+            "version": "2.0.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/html-escaper",
+            "breadcrumb": "jest#@jest/core#@jest/reporters#istanbul-reports#html-escaper"
+          }
+        },
+        {
+          "message": "\"http-errors@1.6.2\" is required at \"apollo-server-micro#micro#raw-body#http-errors\", the latest is 2.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "http-errors",
+            "version": "1.6.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/http-errors",
+            "breadcrumb": "apollo-server-micro#micro#raw-body#http-errors"
+          }
+        },
+        {
+          "message": "\"human-signals@2.1.0\" is required at \"jest#@jest/core#jest-changed-files#execa#human-signals\", the latest is 3.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "human-signals",
+            "version": "2.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/human-signals",
+            "breadcrumb": "jest#@jest/core#jest-changed-files#execa#human-signals"
+          }
+        },
+        {
+          "message": "\"indent-string@4.0.0\" is required at \"@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#p-map#aggregate-error#indent-string\", the latest is 5.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "indent-string",
+            "version": "4.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/indent-string",
+            "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#p-map#aggregate-error#indent-string"
+          }
+        },
+        {
+          "message": "\"is-fullwidth-code-point@3.0.0\" is required at \"yargs#cliui#string-width#is-fullwidth-code-point\", the latest is 4.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "is-fullwidth-code-point",
+            "version": "3.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/is-fullwidth-code-point",
+            "breadcrumb": "yargs#cliui#string-width#is-fullwidth-code-point"
+          }
+        },
+        {
+          "message": "\"is-generator-fn@2.1.0\" is required at \"jest#jest-cli#jest-config#jest-circus#is-generator-fn\", the latest is 3.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "is-generator-fn",
+            "version": "2.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/is-generator-fn",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#is-generator-fn"
+          }
+        },
+        {
+          "message": "\"is-interactive@1.0.0\" is required at \"ora#is-interactive\", the latest is 2.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "is-interactive",
+            "version": "1.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/is-interactive",
+            "breadcrumb": "ora#is-interactive"
+          }
+        },
+        {
+          "message": "\"is-stream@1.1.0\" is required at \"apollo-server-micro#micro#is-stream\", the latest is 3.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "is-stream",
+            "version": "1.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/is-stream",
+            "breadcrumb": "apollo-server-micro#micro#is-stream"
+          }
+        },
+        {
+          "message": "\"is-unicode-supported@0.1.0\" is required at \"ora#log-symbols#is-unicode-supported\", the latest is 1.2.0. This is a major version out of date.",
+          "meta": {
+            "name": "is-unicode-supported",
+            "version": "0.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/is-unicode-supported",
+            "breadcrumb": "ora#log-symbols#is-unicode-supported"
+          }
+        },
+        {
+          "message": "\"jest@27.5.1\" is required at \"jest\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest",
+            "breadcrumb": "jest"
+          }
+        },
+        {
+          "message": "\"jest-changed-files@27.5.1\" is required at \"jest#@jest/core#jest-changed-files\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-changed-files",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-changed-files",
+            "breadcrumb": "jest#@jest/core#jest-changed-files"
+          }
+        },
+        {
+          "message": "\"jest-circus@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-circus\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-circus",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-circus",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus"
+          }
+        },
+        {
+          "message": "\"jest-cli@27.5.1\" is required at \"jest#jest-cli\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-cli",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-cli",
+            "breadcrumb": "jest#jest-cli"
+          }
+        },
+        {
+          "message": "\"jest-config@27.5.1\" is required at \"jest#jest-cli#jest-config\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-config",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-config",
+            "breadcrumb": "jest#jest-cli#jest-config"
+          }
+        },
+        {
+          "message": "\"jest-diff@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-circus#expect#jest-matcher-utils#jest-diff\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-diff",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-diff",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-matcher-utils#jest-diff"
+          }
+        },
+        {
+          "message": "\"jest-docblock@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-runner#jest-docblock\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-docblock",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-docblock",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-runner#jest-docblock"
+          }
+        },
+        {
+          "message": "\"jest-each@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-circus#jest-each\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-each",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-each",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-each"
+          }
+        },
+        {
+          "message": "\"jest-environment-jsdom@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-environment-jsdom",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-environment-jsdom",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom"
+          }
+        },
+        {
+          "message": "\"jest-environment-node@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-environment-node\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-environment-node",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-environment-node",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-node"
+          }
+        },
+        {
+          "message": "\"jest-get-type@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-circus#expect#jest-get-type\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-get-type",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-get-type",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-get-type"
+          }
+        },
+        {
+          "message": "\"jest-haste-map@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-resolve#jest-haste-map\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-haste-map",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-haste-map",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-resolve#jest-haste-map"
+          }
+        },
+        {
+          "message": "\"jest-jasmine2@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-jasmine2\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-jasmine2",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-jasmine2",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-jasmine2"
+          }
+        },
+        {
+          "message": "\"jest-leak-detector@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-runner#jest-leak-detector\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-leak-detector",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-leak-detector",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-runner#jest-leak-detector"
+          }
+        },
+        {
+          "message": "\"jest-message-util@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-circus#expect#jest-message-util\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-message-util",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-message-util",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util"
+          }
+        },
+        {
+          "message": "\"jest-matcher-utils@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-circus#expect#jest-matcher-utils\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-matcher-utils",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-matcher-utils",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-matcher-utils"
+          }
+        },
+        {
+          "message": "\"jest-mock@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jest-mock\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-mock",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-mock",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jest-mock"
+          }
+        },
+        {
+          "message": "\"jest-regex-util@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-regex-util\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-regex-util",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-regex-util",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-regex-util"
+          }
+        },
+        {
+          "message": "\"jest-resolve@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-resolve\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-resolve",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-resolve",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-resolve"
+          }
+        },
+        {
+          "message": "\"jest-resolve-dependencies@27.5.1\" is required at \"jest#@jest/core#jest-resolve-dependencies\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-resolve-dependencies",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-resolve-dependencies",
+            "breadcrumb": "jest#@jest/core#jest-resolve-dependencies"
+          }
+        },
+        {
+          "message": "\"jest-runtime@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-circus#jest-runtime\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-runtime",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-runtime",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-runtime"
+          }
+        },
+        {
+          "message": "\"jest-serializer@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-resolve#jest-haste-map#jest-serializer\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-serializer",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-serializer",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-resolve#jest-haste-map#jest-serializer"
+          }
+        },
+        {
+          "message": "\"jest-runner@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-runner\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-runner",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-runner",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-runner"
+          }
+        },
+        {
+          "message": "\"jest-util@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-circus#jest-util\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-util",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-util",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-util"
+          }
+        },
+        {
+          "message": "\"jest-validate@27.5.1\" is required at \"jest#jest-cli#jest-validate\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-validate",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-validate",
+            "breadcrumb": "jest#jest-cli#jest-validate"
+          }
+        },
+        {
+          "message": "\"jest-snapshot@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-circus#jest-snapshot\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-snapshot",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-snapshot",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-snapshot"
+          }
+        },
+        {
+          "message": "\"jest-worker@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-resolve#jest-haste-map#jest-worker\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-worker",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-worker",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-resolve#jest-haste-map#jest-worker"
+          }
+        },
+        {
+          "message": "\"js-tokens@4.0.0\" is required at \"eslint-config-next#eslint-plugin-react#prop-types#loose-envify#js-tokens\", the latest is 7.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "js-tokens",
+            "version": "4.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/js-tokens",
+            "breadcrumb": "eslint-config-next#eslint-plugin-react#prop-types#loose-envify#js-tokens"
+          }
+        },
+        {
+          "message": "\"jest-watcher@27.5.1\" is required at \"jest#@jest/core#jest-watcher\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jest-watcher",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-watcher",
+            "breadcrumb": "jest#@jest/core#jest-watcher"
+          }
+        },
+        {
+          "message": "\"jsdom@16.7.0\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom\", the latest is 19.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "jsdom",
+            "version": "16.7.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jsdom",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom"
+          }
+        },
+        {
+          "message": "\"jsesc@2.5.2\" is required at \"jest#jest-cli#jest-config#jest-circus#jest-snapshot#@babel/generator#jsesc\", the latest is 3.0.2. This is a major version out of date.",
+          "meta": {
+            "name": "jsesc",
+            "version": "2.5.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jsesc",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-snapshot#@babel/generator#jsesc"
+          }
+        },
+        {
+          "message": "\"json-schema-traverse@0.4.1\" is required at \"eslint-config-next#eslint#ajv#json-schema-traverse\", the latest is 1.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "json-schema-traverse",
+            "version": "0.4.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/json-schema-traverse",
+            "breadcrumb": "eslint-config-next#eslint#ajv#json-schema-traverse"
+          }
+        },
+        {
+          "message": "\"json5@1.0.1\" is required at \"eslint-config-next#eslint-import-resolver-typescript#tsconfig-paths#json5\", the latest is 2.2.1. This is a major version out of date.",
+          "meta": {
+            "name": "json5",
+            "version": "1.0.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/json5",
+            "breadcrumb": "eslint-config-next#eslint-import-resolver-typescript#tsconfig-paths#json5"
+          }
+        },
+        {
+          "message": "\"kleur@3.0.3\" is required at \"jest#jest-cli#prompts#kleur\", the latest is 4.1.4. This is a major version out of date.",
+          "meta": {
+            "name": "kleur",
+            "version": "3.0.3",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/kleur",
+            "breadcrumb": "jest#jest-cli#prompts#kleur"
+          }
+        },
+        {
+          "message": "\"leven@3.1.0\" is required at \"jest#jest-cli#jest-validate#leven\", the latest is 4.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "leven",
+            "version": "3.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/leven",
+            "breadcrumb": "jest#jest-cli#jest-validate#leven"
+          }
+        },
+        {
+          "message": "\"lines-and-columns@1.2.4\" is required at \"jest#jest-cli#jest-config#parse-json#lines-and-columns\", the latest is 2.0.3. This is a major version out of date.",
+          "meta": {
+            "name": "lines-and-columns",
+            "version": "1.2.4",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/lines-and-columns",
+            "breadcrumb": "jest#jest-cli#jest-config#parse-json#lines-and-columns"
+          }
+        },
+        {
+          "message": "\"locate-path@5.0.0\" is required at \"jest#import-local#pkg-dir#find-up#locate-path\", the latest is 7.1.0. This is a major version out of date.",
+          "meta": {
+            "name": "locate-path",
+            "version": "5.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/locate-path",
+            "breadcrumb": "jest#import-local#pkg-dir#find-up#locate-path"
+          }
+        },
+        {
+          "message": "\"log-symbols@4.1.0\" is required at \"ora#log-symbols\", the latest is 5.1.0. This is a major version out of date.",
+          "meta": {
+            "name": "log-symbols",
+            "version": "4.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/log-symbols",
+            "breadcrumb": "ora#log-symbols"
+          }
+        },
+        {
+          "message": "\"log-update@4.0.0\" is required at \"lint-staged#listr2#log-update\", the latest is 5.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "log-update",
+            "version": "4.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/log-update",
+            "breadcrumb": "lint-staged#listr2#log-update"
+          }
+        },
+        {
+          "message": "\"long@4.0.0\" is required at \"apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#long\", the latest is 5.2.0. This is a major version out of date.",
+          "meta": {
+            "name": "long",
+            "version": "4.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/long",
+            "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#long"
+          }
+        },
+        {
+          "message": "\"media-typer@0.3.0\" is required at \"apollo-server-micro#type-is#media-typer\", the latest is 1.1.0. This is a major version out of date.",
+          "meta": {
+            "name": "media-typer",
+            "version": "0.3.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/media-typer",
+            "breadcrumb": "apollo-server-micro#type-is#media-typer"
+          }
+        },
+        {
+          "message": "\"mimic-fn@2.1.0\" is required at \"jest#@jest/core#jest-changed-files#execa#onetime#mimic-fn\", the latest is 4.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "mimic-fn",
+            "version": "2.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/mimic-fn",
+            "breadcrumb": "jest#@jest/core#jest-changed-files#execa#onetime#mimic-fn"
+          }
+        },
+        {
+          "message": "\"minimatch@3.1.2\" is required at \"eslint-config-next#eslint#minimatch\", the latest is 5.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "minimatch",
+            "version": "3.1.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/minimatch",
+            "breadcrumb": "eslint-config-next#eslint#minimatch"
+          }
+        },
+        {
+          "message": "\"node-fetch@2.6.7\" is required at \"apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-env#node-fetch\", the latest is 3.2.3. This is a major version out of date.",
+          "meta": {
+            "name": "node-fetch",
+            "version": "2.6.7",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/node-fetch",
+            "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-env#node-fetch"
+          }
+        },
+        {
+          "message": "\"npm-run-path@4.0.1\" is required at \"jest#@jest/core#jest-changed-files#execa#npm-run-path\", the latest is 5.1.0. This is a major version out of date.",
+          "meta": {
+            "name": "npm-run-path",
+            "version": "4.0.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/npm-run-path",
+            "breadcrumb": "jest#@jest/core#jest-changed-files#execa#npm-run-path"
+          }
+        },
+        {
+          "message": "\"onetime@5.1.2\" is required at \"jest#@jest/core#jest-changed-files#execa#onetime\", the latest is 6.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "onetime",
+            "version": "5.1.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/onetime",
+            "breadcrumb": "jest#@jest/core#jest-changed-files#execa#onetime"
+          }
+        },
+        {
+          "message": "\"ora@5.4.1\" is required at \"ora\", the latest is 6.1.0. This is a major version out of date.",
+          "meta": {
+            "name": "ora",
+            "version": "5.4.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/ora",
+            "breadcrumb": "ora"
+          }
+        },
+        {
+          "message": "\"p-limit@2.3.0\" is required at \"jest#import-local#pkg-dir#find-up#locate-path#p-locate#p-limit\", the latest is 4.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "p-limit",
+            "version": "2.3.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/p-limit",
+            "breadcrumb": "jest#import-local#pkg-dir#find-up#locate-path#p-locate#p-limit"
+          }
+        },
+        {
+          "message": "\"p-locate@4.1.0\" is required at \"jest#import-local#pkg-dir#find-up#locate-path#p-locate\", the latest is 6.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "p-locate",
+            "version": "4.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/p-locate",
+            "breadcrumb": "jest#import-local#pkg-dir#find-up#locate-path#p-locate"
+          }
+        },
+        {
+          "message": "\"p-map@4.0.0\" is required at \"@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#p-map\", the latest is 5.3.0. This is a major version out of date.",
+          "meta": {
+            "name": "p-map",
+            "version": "4.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/p-map",
+            "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#cacache#p-map"
+          }
+        },
+        {
+          "message": "\"p-try@2.2.0\" is required at \"jest#import-local#pkg-dir#find-up#locate-path#p-locate#p-limit#p-try\", the latest is 3.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "p-try",
+            "version": "2.2.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/p-try",
+            "breadcrumb": "jest#import-local#pkg-dir#find-up#locate-path#p-locate#p-limit#p-try"
+          }
+        },
+        {
+          "message": "\"parent-module@1.0.1\" is required at \"eslint-config-next#eslint#import-fresh#parent-module\", the latest is 3.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "parent-module",
+            "version": "1.0.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/parent-module",
+            "breadcrumb": "eslint-config-next#eslint#import-fresh#parent-module"
+          }
+        },
+        {
+          "message": "\"parse-json@5.2.0\" is required at \"jest#jest-cli#jest-config#parse-json\", the latest is 6.0.2. This is a major version out of date.",
+          "meta": {
+            "name": "parse-json",
+            "version": "5.2.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/parse-json",
+            "breadcrumb": "jest#jest-cli#jest-config#parse-json"
+          }
+        },
+        {
+          "message": "\"parse5@6.0.1\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#parse5\", the latest is 7.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "parse5",
+            "version": "6.0.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/parse5",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#parse5"
+          }
+        },
+        {
+          "message": "\"path-exists@4.0.0\" is required at \"jest#import-local#pkg-dir#find-up#path-exists\", the latest is 5.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "path-exists",
+            "version": "4.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/path-exists",
+            "breadcrumb": "jest#import-local#pkg-dir#find-up#path-exists"
+          }
+        },
+        {
+          "message": "\"path-is-absolute@1.0.1\" is required at \"eslint-config-next#eslint-import-resolver-typescript#glob#path-is-absolute\", the latest is 2.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "path-is-absolute",
+            "version": "1.0.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/path-is-absolute",
+            "breadcrumb": "eslint-config-next#eslint-import-resolver-typescript#glob#path-is-absolute"
+          }
+        },
+        {
+          "message": "\"path-key@3.1.1\" is required at \"eslint-config-next#eslint#cross-spawn#path-key\", the latest is 4.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "path-key",
+            "version": "3.1.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/path-key",
+            "breadcrumb": "eslint-config-next#eslint#cross-spawn#path-key"
+          }
+        },
+        {
+          "message": "\"pkg-dir@4.2.0\" is required at \"jest#import-local#pkg-dir\", the latest is 6.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "pkg-dir",
+            "version": "4.2.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/pkg-dir",
+            "breadcrumb": "jest#import-local#pkg-dir"
+          }
+        },
+        {
+          "message": "\"path-type@4.0.0\" is required at \"@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#dir-glob#path-type\", the latest is 5.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "path-type",
+            "version": "4.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/path-type",
+            "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#dir-glob#path-type"
+          }
+        },
+        {
+          "message": "\"pretty-format@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-circus#pretty-format\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "pretty-format",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/pretty-format",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#pretty-format"
+          }
+        },
+        {
+          "message": "\"react-is@17.0.2\" is required at \"jest#jest-cli#jest-config#jest-circus#pretty-format#react-is\", the latest is 18.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "react-is",
+            "version": "17.0.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/react-is",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#pretty-format#react-is"
+          }
+        },
+        {
+          "message": "\"restore-cursor@3.1.0\" is required at \"lint-staged#listr2#log-update#cli-cursor#restore-cursor\", the latest is 4.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "restore-cursor",
+            "version": "3.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/restore-cursor",
+            "breadcrumb": "lint-staged#listr2#log-update#cli-cursor#restore-cursor"
+          }
+        },
+        {
+          "message": "\"saxes@5.0.1\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#saxes\", the latest is 6.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "saxes",
+            "version": "5.0.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/saxes",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#saxes"
+          }
+        },
+        {
+          "message": "\"shebang-regex@3.0.0\" is required at \"eslint-config-next#eslint#cross-spawn#shebang-command#shebang-regex\", the latest is 4.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "shebang-regex",
+            "version": "3.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/shebang-regex",
+            "breadcrumb": "eslint-config-next#eslint#cross-spawn#shebang-command#shebang-regex"
+          }
+        },
+        {
+          "message": "\"slash@3.0.0\" is required at \"jest#jest-cli#jest-config#babel-jest#slash\", the latest is 4.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "slash",
+            "version": "3.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/slash",
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#slash"
+          }
+        },
+        {
+          "message": "\"statuses@1.5.0\" is required at \"apollo-server-micro#micro#raw-body#http-errors#statuses\", the latest is 2.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "statuses",
+            "version": "1.5.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/statuses",
+            "breadcrumb": "apollo-server-micro#micro#raw-body#http-errors#statuses"
+          }
+        },
+        {
+          "message": "\"string-length@4.0.2\" is required at \"jest#@jest/core#jest-watcher#string-length\", the latest is 5.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "string-length",
+            "version": "4.0.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/string-length",
+            "breadcrumb": "jest#@jest/core#jest-watcher#string-length"
+          }
+        },
+        {
+          "message": "\"string-width@4.2.3\" is required at \"yargs#cliui#string-width\", the latest is 5.1.2. This is a major version out of date.",
+          "meta": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/string-width",
+            "breadcrumb": "yargs#cliui#string-width"
+          }
+        },
+        {
+          "message": "\"strip-ansi@6.0.1\" is required at \"yargs#cliui#strip-ansi\", the latest is 7.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "strip-ansi",
+            "version": "6.0.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/strip-ansi",
+            "breadcrumb": "yargs#cliui#strip-ansi"
+          }
+        },
+        {
+          "message": "\"strip-bom@3.0.0\" is required at \"eslint-config-next#eslint-import-resolver-typescript#tsconfig-paths#strip-bom\", the latest is 5.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "strip-bom",
+            "version": "3.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/strip-bom",
+            "breadcrumb": "eslint-config-next#eslint-import-resolver-typescript#tsconfig-paths#strip-bom"
+          }
+        },
+        {
+          "message": "\"strip-final-newline@2.0.0\" is required at \"jest#@jest/core#jest-changed-files#execa#strip-final-newline\", the latest is 3.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "strip-final-newline",
+            "version": "2.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/strip-final-newline",
+            "breadcrumb": "jest#@jest/core#jest-changed-files#execa#strip-final-newline"
+          }
+        },
+        {
+          "message": "\"strip-json-comments@3.1.1\" is required at \"eslint-config-next#eslint#strip-json-comments\", the latest is 4.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "strip-json-comments",
+            "version": "3.1.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/strip-json-comments",
+            "breadcrumb": "eslint-config-next#eslint#strip-json-comments"
+          }
+        },
+        {
+          "message": "\"supports-color@7.2.0\" is required at \"jest#jest-cli#jest-config#babel-jest#chalk#supports-color\", the latest is 9.2.2. This is a major version out of date.",
+          "meta": {
+            "name": "supports-color",
+            "version": "7.2.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/supports-color",
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#chalk#supports-color"
+          }
+        },
+        {
+          "message": "\"terminal-link@2.1.1\" is required at \"jest#@jest/core#@jest/reporters#terminal-link\", the latest is 3.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "terminal-link",
+            "version": "2.1.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/terminal-link",
+            "breadcrumb": "jest#@jest/core#@jest/reporters#terminal-link"
+          }
+        },
+        {
+          "message": "\"to-fast-properties@2.0.0\" is required at \"jest#jest-cli#jest-config#babel-jest#babel-preset-jest#babel-plugin-jest-hoist#@babel/types#to-fast-properties\", the latest is 4.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "to-fast-properties",
+            "version": "2.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/to-fast-properties",
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-preset-jest#babel-plugin-jest-hoist#@babel/types#to-fast-properties"
+          }
+        },
+        {
+          "message": "\"tr46@2.1.0\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#data-urls#whatwg-url#tr46\", the latest is 3.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "tr46",
+            "version": "2.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/tr46",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#data-urls#whatwg-url#tr46"
+          }
+        },
+        {
+          "message": "\"type-fest@0.20.2\" is required at \"eslint-config-next#eslint#globals#type-fest\", the latest is 2.12.2. This is a major version out of date.",
+          "meta": {
+            "name": "type-fest",
+            "version": "0.20.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/type-fest",
+            "breadcrumb": "eslint-config-next#eslint#globals#type-fest"
+          }
+        },
+        {
+          "message": "\"typedarray-to-buffer@3.1.5\" is required at \"jest#jest-cli#jest-config#babel-jest#@jest/transform#write-file-atomic#typedarray-to-buffer\", the latest is 4.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "typedarray-to-buffer",
+            "version": "3.1.5",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/typedarray-to-buffer",
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@jest/transform#write-file-atomic#typedarray-to-buffer"
+          }
+        },
+        {
+          "message": "\"universalify@0.1.2\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#tough-cookie#universalify\", the latest is 2.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "universalify",
+            "version": "0.1.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/universalify",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#tough-cookie#universalify"
+          }
+        },
+        {
+          "message": "\"v8-to-istanbul@8.1.1\" is required at \"jest#@jest/core#@jest/reporters#v8-to-istanbul\", the latest is 9.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "v8-to-istanbul",
+            "version": "8.1.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/v8-to-istanbul",
+            "breadcrumb": "jest#@jest/core#@jest/reporters#v8-to-istanbul"
+          }
+        },
+        {
+          "message": "\"w3c-xmlserializer@2.0.0\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#w3c-xmlserializer\", the latest is 3.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "w3c-xmlserializer",
+            "version": "2.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/w3c-xmlserializer",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#w3c-xmlserializer"
+          }
+        },
+        {
+          "message": "\"webidl-conversions@6.1.0\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#webidl-conversions\", the latest is 7.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "webidl-conversions",
+            "version": "6.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/webidl-conversions",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#webidl-conversions"
+          }
+        },
+        {
+          "message": "\"whatwg-encoding@1.0.5\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#html-encoding-sniffer#whatwg-encoding\", the latest is 2.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "whatwg-encoding",
+            "version": "1.0.5",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/whatwg-encoding",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#html-encoding-sniffer#whatwg-encoding"
+          }
+        },
+        {
+          "message": "\"whatwg-url@8.7.0\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#data-urls#whatwg-url\", the latest is 11.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "whatwg-url",
+            "version": "8.7.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/whatwg-url",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#data-urls#whatwg-url"
+          }
+        },
+        {
+          "message": "\"wrap-ansi@7.0.0\" is required at \"yargs#cliui#wrap-ansi\", the latest is 8.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "wrap-ansi",
+            "version": "7.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/wrap-ansi",
+            "breadcrumb": "yargs#cliui#wrap-ansi"
+          }
+        },
+        {
+          "message": "\"whatwg-mimetype@2.3.0\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#data-urls#whatwg-mimetype\", the latest is 3.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "whatwg-mimetype",
+            "version": "2.3.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/whatwg-mimetype",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#data-urls#whatwg-mimetype"
+          }
+        },
+        {
+          "message": "\"ws@7.5.7\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#ws\", the latest is 8.5.0. This is a major version out of date.",
+          "meta": {
+            "name": "ws",
+            "version": "7.5.7",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/ws",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#ws"
+          }
+        },
+        {
+          "message": "\"xml-name-validator@3.0.0\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#xml-name-validator\", the latest is 4.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "xml-name-validator",
+            "version": "3.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/xml-name-validator",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#xml-name-validator"
+          }
+        },
+        {
+          "message": "\"yaml@1.10.2\" is required at \"lint-staged#yaml\", the latest is 2.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "yaml",
+            "version": "1.10.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/yaml",
+            "breadcrumb": "lint-staged#yaml"
+          }
+        },
+        {
+          "message": "\"@jest/console@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-runner#@jest/console\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "@jest/console",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@jest/console",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-runner#@jest/console"
+          }
+        },
+        {
+          "message": "\"@jest/core@27.5.1\" is required at \"jest#@jest/core\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "@jest/core",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@jest/core",
+            "breadcrumb": "jest#@jest/core"
+          }
+        },
+        {
+          "message": "\"@jest/environment@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-circus#@jest/environment\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "@jest/environment",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@jest/environment",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#@jest/environment"
+          }
+        },
+        {
+          "message": "\"@jest/fake-timers@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#@jest/fake-timers\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "@jest/fake-timers",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@jest/fake-timers",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#@jest/fake-timers"
+          }
+        },
+        {
+          "message": "\"@jest/reporters@27.5.1\" is required at \"jest#@jest/core#@jest/reporters\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "@jest/reporters",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@jest/reporters",
+            "breadcrumb": "jest#@jest/core#@jest/reporters"
+          }
+        },
+        {
+          "message": "\"@jest/globals@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-circus#jest-runtime#@jest/globals\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "@jest/globals",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@jest/globals",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-runtime#@jest/globals"
+          }
+        },
+        {
+          "message": "\"@jest/source-map@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-jasmine2#@jest/source-map\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "@jest/source-map",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@jest/source-map",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-jasmine2#@jest/source-map"
+          }
+        },
+        {
+          "message": "\"@jest/test-result@27.5.1\" is required at \"jest#jest-cli#jest-config#jest-circus#@jest/test-result\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "@jest/test-result",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@jest/test-result",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#@jest/test-result"
+          }
+        },
+        {
+          "message": "\"@jest/test-sequencer@27.5.1\" is required at \"jest#jest-cli#jest-config#@jest/test-sequencer\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "@jest/test-sequencer",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@jest/test-sequencer",
+            "breadcrumb": "jest#jest-cli#jest-config#@jest/test-sequencer"
+          }
+        },
+        {
+          "message": "\"@jest/transform@27.5.1\" is required at \"jest#jest-cli#jest-config#babel-jest#@jest/transform\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "@jest/transform",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@jest/transform",
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@jest/transform"
+          }
+        },
+        {
+          "message": "\"@jest/types@27.5.1\" is required at \"jest#jest-cli#jest-config#babel-jest#@jest/types\", the latest is 28.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "@jest/types",
+            "version": "27.5.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@jest/types",
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@jest/types"
+          }
+        },
+        {
+          "message": "\"@next/swc-darwin-x64@12.1.5\" is required at \"eslint-config-next#next#@next/swc-darwin-x64\", the latest is 11.1.2. This is a major version out of date.",
+          "meta": {
+            "name": "@next/swc-darwin-x64",
+            "version": "12.1.5",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@next/swc-darwin-x64",
+            "breadcrumb": "eslint-config-next#next#@next/swc-darwin-x64"
+          }
+        },
+        {
+          "message": "\"@sinonjs/fake-timers@8.1.0\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#@jest/fake-timers#@sinonjs/fake-timers\", the latest is 9.1.2. This is a major version out of date.",
+          "meta": {
+            "name": "@sinonjs/fake-timers",
+            "version": "8.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@sinonjs/fake-timers",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#@jest/fake-timers#@sinonjs/fake-timers"
+          }
+        },
+        {
+          "message": "\"@tootallnate/once@2.0.0\" is required at \"@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#http-proxy-agent#@tootallnate/once\", the latest is 3.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "@tootallnate/once",
+            "version": "2.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@tootallnate/once",
+            "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#http-proxy-agent#@tootallnate/once"
+          }
+        },
+        {
+          "message": "\"@types/json5@0.0.29\" is required at \"eslint-config-next#eslint-import-resolver-typescript#tsconfig-paths#@types/json5\", the latest is 2.2.0. This is a major version out of date.",
+          "meta": {
+            "name": "@types/json5",
+            "version": "0.0.29",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@types/json5",
+            "breadcrumb": "eslint-config-next#eslint-import-resolver-typescript#tsconfig-paths#@types/json5"
+          }
+        },
+        {
+          "message": "\"@types/yargs@16.0.4\" is required at \"jest#jest-cli#jest-config#babel-jest#@jest/types#@types/yargs\", the latest is 17.0.10. This is a major version out of date.",
+          "meta": {
+            "name": "@types/yargs",
+            "version": "16.0.4",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@types/yargs",
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@jest/types#@types/yargs"
+          }
+        },
+        {
+          "message": "\"acorn@7.4.1\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#acorn-globals#acorn\", the latest is 8.7.0. This is a major version out of date.",
+          "meta": {
+            "name": "acorn",
+            "version": "7.4.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/acorn-globals/node_modules/acorn",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#acorn-globals#acorn"
+          }
+        },
+        {
+          "message": "\"depd@1.1.2\" is required at \"@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#agentkeepalive#depd\", the latest is 2.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "depd",
+            "version": "1.1.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/agentkeepalive/node_modules/depd",
+            "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#agentkeepalive#depd"
+          }
+        },
+        {
+          "message": "\"type-fest@0.21.3\" is required at \"jest#@jest/core#jest-watcher#ansi-escapes#type-fest\", the latest is 2.12.2. This is a major version out of date.",
+          "meta": {
+            "name": "type-fest",
+            "version": "0.21.3",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/ansi-escapes/node_modules/type-fest",
+            "breadcrumb": "jest#@jest/core#jest-watcher#ansi-escapes#type-fest"
+          }
+        },
+        {
+          "message": "\"lru-cache@6.0.0\" is required at \"apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-caching#lru-cache\", the latest is 7.8.1. This is a major version out of date.",
+          "meta": {
+            "name": "lru-cache",
+            "version": "6.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/apollo-server-caching/node_modules/lru-cache",
+            "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-caching#lru-cache"
+          }
+        },
+        {
+          "message": "\"lru-cache@6.0.0\" is required at \"apollo-server-micro#apollo-server-core#lru-cache\", the latest is 7.8.1. This is a major version out of date.",
+          "meta": {
+            "name": "lru-cache",
+            "version": "6.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/apollo-server-core/node_modules/lru-cache",
+            "breadcrumb": "apollo-server-micro#apollo-server-core#lru-cache"
+          }
+        },
+        {
+          "message": "\"webidl-conversions@5.0.0\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#domexception#webidl-conversions\", the latest is 7.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "webidl-conversions",
+            "version": "5.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/domexception/node_modules/webidl-conversions",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#domexception#webidl-conversions"
+          }
+        },
+        {
+          "message": "\"debug@2.6.9\" is required at \"eslint-config-next#eslint-import-resolver-node#debug\", the latest is 4.3.4. This is a major version out of date.",
+          "meta": {
+            "name": "debug",
+            "version": "2.6.9",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-import-resolver-node/node_modules/debug",
+            "breadcrumb": "eslint-config-next#eslint-import-resolver-node#debug"
+          }
+        },
+        {
+          "message": "\"debug@2.6.9\" is required at \"eslint-config-next#eslint-plugin-import#debug\", the latest is 4.3.4. This is a major version out of date.",
+          "meta": {
+            "name": "debug",
+            "version": "2.6.9",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-plugin-import/node_modules/debug",
+            "breadcrumb": "eslint-config-next#eslint-plugin-import#debug"
+          }
+        },
+        {
+          "message": "\"find-up@2.1.0\" is required at \"eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up\", the latest is 6.3.0. This is a major version out of date.",
+          "meta": {
+            "name": "find-up",
+            "version": "2.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-module-utils/node_modules/find-up",
+            "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up"
+          }
+        },
+        {
+          "message": "\"debug@3.2.7\" is required at \"eslint-config-next#eslint-plugin-import#eslint-module-utils#debug\", the latest is 4.3.4. This is a major version out of date.",
+          "meta": {
+            "name": "debug",
+            "version": "3.2.7",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-module-utils/node_modules/debug",
+            "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-module-utils#debug"
+          }
+        },
+        {
+          "message": "\"p-limit@1.3.0\" is required at \"eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path#p-locate#p-limit\", the latest is 4.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "p-limit",
+            "version": "1.3.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-module-utils/node_modules/p-limit",
+            "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path#p-locate#p-limit"
+          }
+        },
+        {
+          "message": "\"locate-path@2.0.0\" is required at \"eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path\", the latest is 7.1.0. This is a major version out of date.",
+          "meta": {
+            "name": "locate-path",
+            "version": "2.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-module-utils/node_modules/locate-path",
+            "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path"
+          }
+        },
+        {
+          "message": "\"p-locate@2.0.0\" is required at \"eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path#p-locate\", the latest is 6.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "p-locate",
+            "version": "2.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-module-utils/node_modules/p-locate",
+            "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path#p-locate"
+          }
+        },
+        {
+          "message": "\"path-exists@3.0.0\" is required at \"eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path#path-exists\", the latest is 5.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "path-exists",
+            "version": "3.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-module-utils/node_modules/path-exists",
+            "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path#path-exists"
+          }
+        },
+        {
+          "message": "\"semver@6.3.0\" is required at \"eslint-config-next#eslint-plugin-react#semver\", the latest is 7.3.7. This is a major version out of date.",
+          "meta": {
+            "name": "semver",
+            "version": "6.3.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-plugin-react/node_modules/semver",
+            "breadcrumb": "eslint-config-next#eslint-plugin-react#semver"
+          }
+        },
+        {
+          "message": "\"p-try@1.0.0\" is required at \"eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path#p-locate#p-limit#p-try\", the latest is 3.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "p-try",
+            "version": "1.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-module-utils/node_modules/p-try",
+            "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-module-utils#find-up#locate-path#p-locate#p-limit#p-try"
+          }
+        },
+        {
+          "message": "\"eslint-visitor-keys@2.1.0\" is required at \"eslint-config-next#eslint#eslint-utils#eslint-visitor-keys\", the latest is 3.3.0. This is a major version out of date.",
+          "meta": {
+            "name": "eslint-visitor-keys",
+            "version": "2.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-utils/node_modules/eslint-visitor-keys",
+            "breadcrumb": "eslint-config-next#eslint#eslint-utils#eslint-visitor-keys"
+          }
+        },
+        {
+          "message": "\"is-stream@2.0.1\" is required at \"jest#@jest/core#jest-changed-files#execa#is-stream\", the latest is 3.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "is-stream",
+            "version": "2.0.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/execa/node_modules/is-stream",
+            "breadcrumb": "jest#@jest/core#jest-changed-files#execa#is-stream"
+          }
+        },
+        {
+          "message": "\"glob-parent@5.1.2\" is required at \"@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#fast-glob#glob-parent\", the latest is 6.0.2. This is a major version out of date.",
+          "meta": {
+            "name": "glob-parent",
+            "version": "5.1.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/fast-glob/node_modules/glob-parent",
+            "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#globby#fast-glob#glob-parent"
+          }
+        },
+        {
+          "message": "\"resolve-from@4.0.0\" is required at \"eslint-config-next#eslint#import-fresh#resolve-from\", the latest is 5.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "resolve-from",
+            "version": "4.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/import-fresh/node_modules/resolve-from",
+            "breadcrumb": "eslint-config-next#eslint#import-fresh#resolve-from"
+          }
+        },
+        {
+          "message": "\"semver@6.3.0\" is required at \"jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#istanbul-lib-instrument#semver\", the latest is 7.3.7. This is a major version out of date.",
+          "meta": {
+            "name": "semver",
+            "version": "6.3.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/istanbul-lib-instrument/node_modules/semver",
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#istanbul-lib-instrument#semver"
+          }
+        },
+        {
+          "message": "\"yargs@16.2.0\" is required at \"jest#jest-cli#yargs\", the latest is 17.4.1. This is a major version out of date.",
+          "meta": {
+            "name": "yargs",
+            "version": "16.2.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-cli/node_modules/yargs",
+            "breadcrumb": "jest#jest-cli#yargs"
+          }
+        },
+        {
+          "message": "\"strip-bom@4.0.0\" is required at \"jest#jest-cli#jest-config#jest-circus#jest-runtime#strip-bom\", the latest is 5.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "strip-bom",
+            "version": "4.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-runtime/node_modules/strip-bom",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-runtime#strip-bom"
+          }
+        },
+        {
+          "message": "\"yargs-parser@20.2.9\" is required at \"jest#jest-cli#yargs#yargs-parser\", the latest is 21.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "yargs-parser",
+            "version": "20.2.9",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-cli/node_modules/yargs-parser",
+            "breadcrumb": "jest#jest-cli#yargs#yargs-parser"
+          }
+        },
+        {
+          "message": "\"supports-color@8.1.1\" is required at \"jest#jest-cli#jest-config#jest-resolve#jest-haste-map#jest-worker#supports-color\", the latest is 9.2.2. This is a major version out of date.",
+          "meta": {
+            "name": "supports-color",
+            "version": "8.1.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jest-worker/node_modules/supports-color",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-resolve#jest-haste-map#jest-worker#supports-color"
+          }
+        },
+        {
+          "message": "\"cli-truncate@2.1.0\" is required at \"lint-staged#listr2#cli-truncate\", the latest is 3.1.0. This is a major version out of date.",
+          "meta": {
+            "name": "cli-truncate",
+            "version": "2.1.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/listr2/node_modules/cli-truncate",
+            "breadcrumb": "lint-staged#listr2#cli-truncate"
+          }
+        },
+        {
+          "message": "\"slice-ansi@3.0.0\" is required at \"lint-staged#listr2#cli-truncate#slice-ansi\", the latest is 5.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "slice-ansi",
+            "version": "3.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/listr2/node_modules/slice-ansi",
+            "breadcrumb": "lint-staged#listr2#cli-truncate#slice-ansi"
+          }
+        },
+        {
+          "message": "\"slice-ansi@4.0.0\" is required at \"lint-staged#listr2#log-update#slice-ansi\", the latest is 5.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "slice-ansi",
+            "version": "4.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/log-update/node_modules/slice-ansi",
+            "breadcrumb": "lint-staged#listr2#log-update#slice-ansi"
+          }
+        },
+        {
+          "message": "\"semver@6.3.0\" is required at \"jest#@jest/core#@jest/reporters#istanbul-reports#istanbul-lib-report#make-dir#semver\", the latest is 7.3.7. This is a major version out of date.",
+          "meta": {
+            "name": "semver",
+            "version": "6.3.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/make-dir/node_modules/semver",
+            "breadcrumb": "jest#@jest/core#@jest/reporters#istanbul-reports#istanbul-lib-report#make-dir#semver"
+          }
+        },
+        {
+          "message": "\"wrap-ansi@6.2.0\" is required at \"lint-staged#listr2#log-update#wrap-ansi\", the latest is 8.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "wrap-ansi",
+            "version": "6.2.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/log-update/node_modules/wrap-ansi",
+            "breadcrumb": "lint-staged#listr2#log-update#wrap-ansi"
+          }
+        },
+        {
+          "message": "\"tr46@0.0.3\" is required at \"apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-env#node-fetch#whatwg-url#tr46\", the latest is 3.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "tr46",
+            "version": "0.0.3",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/node-fetch/node_modules/tr46",
+            "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-env#node-fetch#whatwg-url#tr46"
+          }
+        },
+        {
+          "message": "\"webidl-conversions@3.0.1\" is required at \"apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-env#node-fetch#whatwg-url#webidl-conversions\", the latest is 7.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "webidl-conversions",
+            "version": "3.0.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/node-fetch/node_modules/webidl-conversions",
+            "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-env#node-fetch#whatwg-url#webidl-conversions"
+          }
+        },
+        {
+          "message": "\"whatwg-url@5.0.0\" is required at \"apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-env#node-fetch#whatwg-url\", the latest is 11.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "whatwg-url",
+            "version": "5.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/node-fetch/node_modules/whatwg-url",
+            "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-datasource#apollo-server-env#node-fetch#whatwg-url"
+          }
+        },
+        {
+          "message": "\"ansi-styles@5.2.0\" is required at \"jest#jest-cli#jest-config#jest-circus#pretty-format#ansi-styles\", the latest is 6.1.0. This is a major version out of date.",
+          "meta": {
+            "name": "ansi-styles",
+            "version": "5.2.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/pretty-format/node_modules/ansi-styles",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#pretty-format#ansi-styles"
+          }
+        },
+        {
+          "message": "\"react-is@16.13.1\" is required at \"eslint-config-next#eslint-plugin-react#prop-types#react-is\", the latest is 18.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "react-is",
+            "version": "16.13.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/prop-types/node_modules/react-is",
+            "breadcrumb": "eslint-config-next#eslint-plugin-react#prop-types#react-is"
+          }
+        },
+        {
+          "message": "\"lru-cache@6.0.0\" is required at \"@npmcli/arborist#pacote#npm-pick-manifest#npm-package-arg#validate-npm-package-name#builtins#semver#lru-cache\", the latest is 7.8.1. This is a major version out of date.",
+          "meta": {
+            "name": "lru-cache",
+            "version": "6.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/semver/node_modules/lru-cache",
+            "breadcrumb": "@npmcli/arborist#pacote#npm-pick-manifest#npm-package-arg#validate-npm-package-name#builtins#semver#lru-cache"
+          }
+        },
+        {
+          "message": "\"escape-string-regexp@2.0.0\" is required at \"jest#jest-cli#jest-config#jest-circus#stack-utils#escape-string-regexp\", the latest is 5.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "escape-string-regexp",
+            "version": "2.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/stack-utils/node_modules/escape-string-regexp",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#stack-utils#escape-string-regexp"
+          }
+        },
+        {
+          "message": "\"emoji-regex@8.0.0\" is required at \"yargs#cliui#string-width#emoji-regex\", the latest is 10.1.0. This is a major version out of date.",
+          "meta": {
+            "name": "emoji-regex",
+            "version": "8.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/string-width/node_modules/emoji-regex",
+            "breadcrumb": "yargs#cliui#string-width#emoji-regex"
+          }
+        },
+        {
+          "message": "\"tslib@1.14.1\" is required at \"@typescript-eslint/eslint-plugin#tsutils#tslib\", the latest is 2.4.0. This is a major version out of date.",
+          "meta": {
+            "name": "tslib",
+            "version": "1.14.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/tsutils/node_modules/tslib",
+            "breadcrumb": "@typescript-eslint/eslint-plugin#tsutils#tslib"
+          }
+        },
+        {
+          "message": "\"commander@2.20.3\" is required at \"apollo-server-micro#apollo-server-core#@apollographql/graphql-playground-html#xss#commander\", the latest is 9.2.0. This is a major version out of date.",
+          "meta": {
+            "name": "commander",
+            "version": "2.20.3",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/xss/node_modules/commander",
+            "breadcrumb": "apollo-server-micro#apollo-server-core#@apollographql/graphql-playground-html#xss#commander"
+          }
+        },
+        {
+          "message": "\"semver@6.3.0\" is required at \"jest#jest-cli#jest-config#babel-jest#@babel/core#semver\", the latest is 7.3.7. This is a major version out of date.",
+          "meta": {
+            "name": "semver",
+            "version": "6.3.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@babel/core/node_modules/semver",
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#semver"
+          }
+        },
+        {
+          "message": "\"ansi-styles@3.2.1\" is required at \"jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#ansi-styles\", the latest is 6.1.0. This is a major version out of date.",
+          "meta": {
+            "name": "ansi-styles",
+            "version": "3.2.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@babel/highlight/node_modules/ansi-styles",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#ansi-styles"
+          }
+        },
+        {
+          "message": "\"semver@6.3.0\" is required at \"jest#jest-cli#jest-config#babel-jest#@babel/core#@babel/helper-compilation-targets#semver\", the latest is 7.3.7. This is a major version out of date.",
+          "meta": {
+            "name": "semver",
+            "version": "6.3.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@babel/helper-compilation-targets/node_modules/semver",
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@babel/core#@babel/helper-compilation-targets#semver"
+          }
+        },
+        {
+          "message": "\"chalk@2.4.2\" is required at \"jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk\", the latest is 5.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "chalk",
+            "version": "2.4.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@babel/highlight/node_modules/chalk",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk"
+          }
+        },
+        {
+          "message": "\"color-convert@1.9.3\" is required at \"jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#ansi-styles#color-convert\", the latest is 2.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "color-convert",
+            "version": "1.9.3",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@babel/highlight/node_modules/color-convert",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#ansi-styles#color-convert"
+          }
+        },
+        {
+          "message": "\"has-flag@3.0.0\" is required at \"jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#supports-color#has-flag\", the latest is 5.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "has-flag",
+            "version": "3.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@babel/highlight/node_modules/has-flag",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#supports-color#has-flag"
+          }
+        },
+        {
+          "message": "\"supports-color@5.5.0\" is required at \"jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#supports-color\", the latest is 9.2.2. This is a major version out of date.",
+          "meta": {
+            "name": "supports-color",
+            "version": "5.5.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@babel/highlight/node_modules/supports-color",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#supports-color"
+          }
+        },
+        {
+          "message": "\"globals@11.12.0\" is required at \"jest#jest-cli#jest-config#jest-circus#jest-snapshot#@babel/traverse#globals\", the latest is 13.13.0. This is a major version out of date.",
+          "meta": {
+            "name": "globals",
+            "version": "11.12.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@babel/traverse/node_modules/globals",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-snapshot#@babel/traverse#globals"
+          }
+        },
+        {
+          "message": "\"argparse@1.0.10\" is required at \"jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@istanbuljs/load-nyc-config#js-yaml#argparse\", the latest is 2.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "argparse",
+            "version": "1.0.10",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@istanbuljs/load-nyc-config/node_modules/argparse",
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@istanbuljs/load-nyc-config#js-yaml#argparse"
+          }
+        },
+        {
+          "message": "\"escape-string-regexp@1.0.5\" is required at \"jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#escape-string-regexp\", the latest is 5.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "escape-string-regexp",
+            "version": "1.0.5",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@babel/highlight/node_modules/escape-string-regexp",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#escape-string-regexp"
+          }
+        },
+        {
+          "message": "\"camelcase@5.3.1\" is required at \"jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@istanbuljs/load-nyc-config#camelcase\", the latest is 6.3.0. This is a major version out of date.",
+          "meta": {
+            "name": "camelcase",
+            "version": "5.3.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase",
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@istanbuljs/load-nyc-config#camelcase"
+          }
+        },
+        {
+          "message": "\"write-file-atomic@3.0.3\" is required at \"jest#jest-cli#jest-config#babel-jest#@jest/transform#write-file-atomic\", the latest is 4.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "write-file-atomic",
+            "version": "3.0.3",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@jest/transform/node_modules/write-file-atomic",
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#@jest/transform#write-file-atomic"
+          }
+        },
+        {
+          "message": "\"js-yaml@3.14.1\" is required at \"jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@istanbuljs/load-nyc-config#js-yaml\", the latest is 4.1.0. This is a major version out of date.",
+          "meta": {
+            "name": "js-yaml",
+            "version": "3.14.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml",
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@istanbuljs/load-nyc-config#js-yaml"
+          }
+        },
+        {
+          "message": "\"eslint-scope@5.1.1\" is required at \"@typescript-eslint/eslint-plugin#@typescript-eslint/utils#eslint-scope\", the latest is 7.1.1. This is a major version out of date.",
+          "meta": {
+            "name": "eslint-scope",
+            "version": "5.1.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@typescript-eslint/utils/node_modules/eslint-scope",
+            "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/utils#eslint-scope"
+          }
+        },
+        {
+          "message": "\"glob@7.1.7\" is required at \"eslint-config-next#@next/eslint-plugin-next#glob\", the latest is 8.0.1. This is a major version out of date.",
+          "meta": {
+            "name": "glob",
+            "version": "7.1.7",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@next/eslint-plugin-next/node_modules/glob",
+            "breadcrumb": "eslint-config-next#@next/eslint-plugin-next#glob"
+          }
+        },
+        {
+          "message": "\"estraverse@4.3.0\" is required at \"@typescript-eslint/eslint-plugin#@typescript-eslint/utils#eslint-scope#estraverse\", the latest is 5.3.0. This is a major version out of date.",
+          "meta": {
+            "name": "estraverse",
+            "version": "4.3.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@typescript-eslint/utils/node_modules/estraverse",
+            "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/utils#eslint-scope#estraverse"
+          }
+        },
+        {
+          "message": "\"http-proxy-agent@4.0.1\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#http-proxy-agent\", the latest is 5.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "http-proxy-agent",
+            "version": "4.0.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jsdom/node_modules/http-proxy-agent",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#http-proxy-agent"
+          }
+        },
+        {
+          "message": "\"@tootallnate/once@1.1.2\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#http-proxy-agent#@tootallnate/once\", the latest is 3.0.0. This is a major version out of date.",
+          "meta": {
+            "name": "@tootallnate/once",
+            "version": "1.1.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/jsdom/node_modules/@tootallnate/once",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#http-proxy-agent#@tootallnate/once"
+          }
+        },
+        {
+          "message": "\"@types/node@10.17.60\" is required at \"apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@types/node\", the latest is 17.0.27. This is a major version out of date.",
+          "meta": {
+            "name": "@types/node",
+            "version": "10.17.60",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@apollo/protobufjs/node_modules/@types/node",
+            "breadcrumb": "apollo-server-micro#apollo-server-core#apollo-reporting-protobuf#@apollo/protobufjs#@types/node"
+          }
+        },
+        {
+          "message": "\"@typescript-eslint/types@3.10.1\" is required at \"@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#@typescript-eslint/types\", the latest is 5.21.0. This is a major version out of date.",
+          "meta": {
+            "name": "@typescript-eslint/types",
+            "version": "3.10.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/types",
+            "breadcrumb": "@typescript-eslint/eslint-plugin#@typescript-eslint/parser#@typescript-eslint/typescript-estree#@typescript-eslint/types"
+          }
+        },
+        {
+          "message": "\"debug@3.2.7\" is required at \"eslint-config-next#eslint-plugin-import#eslint-import-resolver-node#debug\", the latest is 4.3.4. This is a major version out of date.",
+          "meta": {
+            "name": "debug",
+            "version": "3.2.7",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-plugin-import/node_modules/eslint-import-resolver-node/node_modules/debug",
+            "breadcrumb": "eslint-config-next#eslint-plugin-import#eslint-import-resolver-node#debug"
+          }
+        },
+        {
+          "message": "\"bytes@3.0.0\" is required at \"apollo-server-micro#micro#raw-body#bytes\", the latest is 3.1.2. This is a minor version out of date.",
+          "meta": {
+            "name": "bytes",
+            "version": "3.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/bytes",
+            "breadcrumb": "apollo-server-micro#micro#raw-body#bytes"
+          }
+        },
+        {
+          "message": "\"cssom@0.4.4\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#cssom\", the latest is 0.5.0. This is a minor version out of date.",
+          "meta": {
+            "name": "cssom",
+            "version": "0.4.4",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/cssom",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#cssom"
+          }
+        },
+        {
+          "message": "\"emittery@0.8.1\" is required at \"jest#jest-cli#jest-config#jest-runner#emittery\", the latest is 0.10.2. This is a minor version out of date.",
+          "meta": {
+            "name": "emittery",
+            "version": "0.8.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/emittery",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-runner#emittery"
+          }
+        },
+        {
+          "message": "\"eslint-import-resolver-typescript@2.4.0\" is required at \"eslint-config-next#eslint-import-resolver-typescript\", the latest is 2.7.1. This is a minor version out of date.",
+          "meta": {
+            "name": "eslint-import-resolver-typescript",
+            "version": "2.4.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-import-resolver-typescript",
+            "breadcrumb": "eslint-config-next#eslint-import-resolver-typescript"
+          }
+        },
+        {
+          "message": "\"eslint-plugin-import@2.25.2\" is required at \"eslint-config-next#eslint-plugin-import\", the latest is 2.26.0. This is a minor version out of date.",
+          "meta": {
+            "name": "eslint-plugin-import",
+            "version": "2.25.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-plugin-import",
+            "breadcrumb": "eslint-config-next#eslint-plugin-import"
+          }
+        },
+        {
+          "message": "\"eslint-plugin-react-hooks@4.3.0\" is required at \"eslint-config-next#eslint-plugin-react-hooks\", the latest is 4.4.0. This is a minor version out of date.",
+          "meta": {
+            "name": "eslint-plugin-react-hooks",
+            "version": "4.3.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-plugin-react-hooks",
+            "breadcrumb": "eslint-config-next#eslint-plugin-react-hooks"
+          }
+        },
+        {
+          "message": "\"iconv-lite@0.4.19\" is required at \"apollo-server-micro#micro#raw-body#iconv-lite\", the latest is 0.6.3. This is a minor version out of date.",
+          "meta": {
+            "name": "iconv-lite",
+            "version": "0.4.19",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/iconv-lite",
+            "breadcrumb": "apollo-server-micro#micro#raw-body#iconv-lite"
+          }
+        },
+        {
+          "message": "\"is-arrayish@0.2.1\" is required at \"jest#jest-cli#jest-config#parse-json#error-ex#is-arrayish\", the latest is 0.3.2. This is a minor version out of date.",
+          "meta": {
+            "name": "is-arrayish",
+            "version": "0.2.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/is-arrayish",
+            "breadcrumb": "jest#jest-cli#jest-config#parse-json#error-ex#is-arrayish"
+          }
+        },
+        {
+          "message": "\"prelude-ls@1.1.2\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator#levn#type-check#prelude-ls\", the latest is 1.2.1. This is a minor version out of date.",
+          "meta": {
+            "name": "prelude-ls",
+            "version": "1.1.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/prelude-ls",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator#levn#type-check#prelude-ls"
+          }
+        },
+        {
+          "message": "\"raw-body@2.3.2\" is required at \"apollo-server-micro#micro#raw-body\", the latest is 2.5.1. This is a minor version out of date.",
+          "meta": {
+            "name": "raw-body",
+            "version": "2.3.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/raw-body",
+            "breadcrumb": "apollo-server-micro#micro#raw-body"
+          }
+        },
+        {
+          "message": "\"setprototypeof@1.0.3\" is required at \"apollo-server-micro#micro#raw-body#http-errors#setprototypeof\", the latest is 1.2.0. This is a minor version out of date.",
+          "meta": {
+            "name": "setprototypeof",
+            "version": "1.0.3",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/setprototypeof",
+            "breadcrumb": "apollo-server-micro#micro#raw-body#http-errors#setprototypeof"
+          }
+        },
+        {
+          "message": "\"source-map@0.6.1\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#source-map\", the latest is 0.7.3. This is a minor version out of date.",
+          "meta": {
+            "name": "source-map",
+            "version": "0.6.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/source-map",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#source-map"
+          }
+        },
+        {
+          "message": "\"sprintf-js@1.0.3\" is required at \"jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@istanbuljs/load-nyc-config#js-yaml#argparse#sprintf-js\", the latest is 1.1.2. This is a minor version out of date.",
+          "meta": {
+            "name": "sprintf-js",
+            "version": "1.0.3",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/sprintf-js",
+            "breadcrumb": "jest#jest-cli#jest-config#babel-jest#babel-plugin-istanbul#@istanbuljs/load-nyc-config#js-yaml#argparse#sprintf-js"
+          }
+        },
+        {
+          "message": "\"tslib@2.3.1\" is required at \"apollo-server-micro#apollo-server-core#@graphql-tools/mock#tslib\", the latest is 2.4.0. This is a minor version out of date.",
+          "meta": {
+            "name": "tslib",
+            "version": "2.3.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/tslib",
+            "breadcrumb": "apollo-server-micro#apollo-server-core#@graphql-tools/mock#tslib"
+          }
+        },
+        {
+          "message": "\"type-check@0.3.2\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator#levn#type-check\", the latest is 0.4.0. This is a minor version out of date.",
+          "meta": {
+            "name": "type-check",
+            "version": "0.3.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/type-check",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator#levn#type-check"
+          }
+        },
+        {
+          "message": "\"@humanwhocodes/config-array@0.9.5\" is required at \"eslint-config-next#eslint#@humanwhocodes/config-array\", the latest is 0.10.2. This is a minor version out of date.",
+          "meta": {
+            "name": "@humanwhocodes/config-array",
+            "version": "0.9.5",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@humanwhocodes/config-array",
+            "breadcrumb": "eslint-config-next#eslint#@humanwhocodes/config-array"
+          }
+        },
+        {
+          "message": "\"@rushstack/eslint-patch@1.0.8\" is required at \"eslint-config-next#@rushstack/eslint-patch\", the latest is 1.1.3. This is a minor version out of date.",
+          "meta": {
+            "name": "@rushstack/eslint-patch",
+            "version": "1.0.8",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@rushstack/eslint-patch",
+            "breadcrumb": "eslint-config-next#@rushstack/eslint-patch"
+          }
+        },
+        {
+          "message": "\"@typescript-eslint/visitor-keys@5.10.1\" is required at \"eslint-config-next#@typescript-eslint/parser#@typescript-eslint/scope-manager#@typescript-eslint/visitor-keys\", the latest is 5.21.0. This is a minor version out of date.",
+          "meta": {
+            "name": "@typescript-eslint/visitor-keys",
+            "version": "5.10.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@typescript-eslint/visitor-keys",
+            "breadcrumb": "eslint-config-next#@typescript-eslint/parser#@typescript-eslint/scope-manager#@typescript-eslint/visitor-keys"
+          }
+        },
+        {
+          "message": "\"cssom@0.3.8\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#cssstyle#cssom\", the latest is 0.5.0. This is a minor version out of date.",
+          "meta": {
+            "name": "cssom",
+            "version": "0.3.8",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/cssstyle/node_modules/cssom",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#cssstyle#cssom"
+          }
+        },
+        {
+          "message": "\"safe-buffer@5.1.2\" is required at \"jest#@jest/core#@jest/reporters#v8-to-istanbul#convert-source-map#safe-buffer\", the latest is 5.2.1. This is a minor version out of date.",
+          "meta": {
+            "name": "safe-buffer",
+            "version": "5.1.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/convert-source-map/node_modules/safe-buffer",
+            "breadcrumb": "jest#@jest/core#@jest/reporters#v8-to-istanbul#convert-source-map#safe-buffer"
+          }
+        },
+        {
+          "message": "\"levn@0.3.0\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator#levn\", the latest is 0.4.1. This is a minor version out of date.",
+          "meta": {
+            "name": "levn",
+            "version": "0.3.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/escodegen/node_modules/levn",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator#levn"
+          }
+        },
+        {
+          "message": "\"optionator@0.8.3\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator\", the latest is 0.9.1. This is a minor version out of date.",
+          "meta": {
+            "name": "optionator",
+            "version": "0.8.3",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/escodegen/node_modules/optionator",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#escodegen#optionator"
+          }
+        },
+        {
+          "message": "\"ms@2.0.0\" is required at \"eslint-config-next#eslint-import-resolver-node#debug#ms\", the latest is 2.1.3. This is a minor version out of date.",
+          "meta": {
+            "name": "ms",
+            "version": "2.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-import-resolver-node/node_modules/ms",
+            "breadcrumb": "eslint-config-next#eslint-import-resolver-node#debug#ms"
+          }
+        },
+        {
+          "message": "\"ms@2.0.0\" is required at \"eslint-config-next#eslint-plugin-import#debug#ms\", the latest is 2.1.3. This is a minor version out of date.",
+          "meta": {
+            "name": "ms",
+            "version": "2.0.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-plugin-import/node_modules/ms",
+            "breadcrumb": "eslint-config-next#eslint-plugin-import#debug#ms"
+          }
+        },
+        {
+          "message": "\"retry@0.12.0\" is required at \"@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#promise-retry#retry\", the latest is 0.13.1. This is a minor version out of date.",
+          "meta": {
+            "name": "retry",
+            "version": "0.12.0",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/promise-retry/node_modules/retry",
+            "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#promise-retry#retry"
+          }
+        },
+        {
+          "message": "\"iconv-lite@0.4.24\" is required at \"jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#html-encoding-sniffer#whatwg-encoding#iconv-lite\", the latest is 0.6.3. This is a minor version out of date.",
+          "meta": {
+            "name": "iconv-lite",
+            "version": "0.4.24",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/whatwg-encoding/node_modules/iconv-lite",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-environment-jsdom#jsdom#html-encoding-sniffer#whatwg-encoding#iconv-lite"
+          }
+        },
+        {
+          "message": "\"source-map@0.5.7\" is required at \"jest#jest-cli#jest-config#jest-circus#jest-snapshot#@babel/generator#source-map\", the latest is 0.7.3. This is a minor version out of date.",
+          "meta": {
+            "name": "source-map",
+            "version": "0.5.7",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@babel/generator/node_modules/source-map",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#jest-snapshot#@babel/generator#source-map"
+          }
+        },
+        {
+          "message": "\"@typescript-eslint/parser@5.10.1\" is required at \"eslint-config-next#@typescript-eslint/parser\", the latest is 5.21.0. This is a minor version out of date.",
+          "meta": {
+            "name": "@typescript-eslint/parser",
+            "version": "5.10.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-config-next/node_modules/@typescript-eslint/parser",
+            "breadcrumb": "eslint-config-next#@typescript-eslint/parser"
+          }
+        },
+        {
+          "message": "\"@typescript-eslint/scope-manager@5.10.1\" is required at \"eslint-config-next#@typescript-eslint/parser#@typescript-eslint/scope-manager\", the latest is 5.21.0. This is a minor version out of date.",
+          "meta": {
+            "name": "@typescript-eslint/scope-manager",
+            "version": "5.10.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-config-next/node_modules/@typescript-eslint/scope-manager",
+            "breadcrumb": "eslint-config-next#@typescript-eslint/parser#@typescript-eslint/scope-manager"
+          }
+        },
+        {
+          "message": "\"@typescript-eslint/typescript-estree@5.10.1\" is required at \"eslint-config-next#@typescript-eslint/parser#@typescript-eslint/typescript-estree\", the latest is 5.21.0. This is a minor version out of date.",
+          "meta": {
+            "name": "@typescript-eslint/typescript-estree",
+            "version": "5.10.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-config-next/node_modules/@typescript-eslint/typescript-estree",
+            "breadcrumb": "eslint-config-next#@typescript-eslint/parser#@typescript-eslint/typescript-estree"
+          }
+        },
+        {
+          "message": "\"@typescript-eslint/types@5.10.1\" is required at \"eslint-config-next#@typescript-eslint/parser#@typescript-eslint/types\", the latest is 5.21.0. This is a minor version out of date.",
+          "meta": {
+            "name": "@typescript-eslint/types",
+            "version": "5.10.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-config-next/node_modules/@typescript-eslint/types",
+            "breadcrumb": "eslint-config-next#@typescript-eslint/parser#@typescript-eslint/types"
+          }
+        },
+        {
+          "message": "\"@typescript-eslint/types@5.10.1\" is required at \"eslint-config-next#@typescript-eslint/parser#@typescript-eslint/scope-manager#@typescript-eslint/visitor-keys#@typescript-eslint/types\", the latest is 5.21.0. This is a minor version out of date.",
+          "meta": {
+            "name": "@typescript-eslint/types",
+            "version": "5.10.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@typescript-eslint/visitor-keys/node_modules/@typescript-eslint/types",
+            "breadcrumb": "eslint-config-next#@typescript-eslint/parser#@typescript-eslint/scope-manager#@typescript-eslint/visitor-keys#@typescript-eslint/types"
+          }
+        },
+        {
+          "message": "\"eslint-import-resolver-node@0.3.4\" is required at \"eslint-config-next#eslint-import-resolver-node\", the latest is 0.3.6. This is a patch version out of date.",
+          "meta": {
+            "name": "eslint-import-resolver-node",
+            "version": "0.3.4",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-import-resolver-node",
+            "breadcrumb": "eslint-config-next#eslint-import-resolver-node"
+          }
+        },
+        {
+          "message": "\"eslint-plugin-react@7.29.1\" is required at \"eslint-config-next#eslint-plugin-react\", the latest is 7.29.4. This is a patch version out of date.",
+          "meta": {
+            "name": "eslint-plugin-react",
+            "version": "7.29.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/eslint-plugin-react",
+            "breadcrumb": "eslint-config-next#eslint-plugin-react"
+          }
+        },
+        {
+          "message": "\"lilconfig@2.0.4\" is required at \"lint-staged#lilconfig\", the latest is 2.0.5. This is a patch version out of date.",
+          "meta": {
+            "name": "lilconfig",
+            "version": "2.0.4",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/lilconfig",
+            "breadcrumb": "lint-staged#lilconfig"
+          }
+        },
+        {
+          "message": "\"postcss@8.4.5\" is required at \"eslint-config-next#next#postcss\", the latest is 8.4.12. This is a patch version out of date.",
+          "meta": {
+            "name": "postcss",
+            "version": "8.4.5",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/postcss",
+            "breadcrumb": "eslint-config-next#next#postcss"
+          }
+        },
+        {
+          "message": "\"styled-jsx@5.0.1\" is required at \"eslint-config-next#next#styled-jsx\", the latest is 5.0.2. This is a patch version out of date.",
+          "meta": {
+            "name": "styled-jsx",
+            "version": "5.0.1",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/styled-jsx",
+            "breadcrumb": "eslint-config-next#next#styled-jsx"
+          }
+        },
+        {
+          "message": "\"@types/react@18.0.6\" is required at \"@types/react-dom#@types/react\", the latest is 18.0.7. This is a patch version out of date.",
+          "meta": {
+            "name": "@types/react",
+            "version": "18.0.6",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@types/react",
+            "breadcrumb": "@types/react-dom#@types/react"
+          }
+        },
+        {
+          "message": "\"ms@2.1.2\" is required at \"@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#agentkeepalive#debug#ms\", the latest is 2.1.3. This is a patch version out of date.",
+          "meta": {
+            "name": "ms",
+            "version": "2.1.2",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/debug/node_modules/ms",
+            "breadcrumb": "@npmcli/arborist#pacote#@npmcli/run-script#node-gyp#make-fetch-happen#agentkeepalive#debug#ms"
+          }
+        },
+        {
+          "message": "\"inherits@2.0.3\" is required at \"apollo-server-micro#micro#raw-body#http-errors#inherits\", the latest is 2.0.4. This is a patch version out of date.",
+          "meta": {
+            "name": "inherits",
+            "version": "2.0.3",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/http-errors/node_modules/inherits",
+            "breadcrumb": "apollo-server-micro#micro#raw-body#http-errors#inherits"
+          }
+        },
+        {
+          "message": "\"color-name@1.1.3\" is required at \"jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#ansi-styles#color-convert#color-name\", the latest is 1.1.4. This is a patch version out of date.",
+          "meta": {
+            "name": "color-name",
+            "version": "1.1.3",
+            "directory": "/Users/gcsapo/Documents/package-inspector/node_modules/@babel/highlight/node_modules/color-name",
+            "breadcrumb": "jest#jest-cli#jest-config#jest-circus#expect#jest-message-util#@babel/code-frame#@babel/highlight#chalk#ansi-styles#color-convert#color-name"
+          }
+        }
+      ]
+    },
+    {
+      "id": "topLevelDepsFreshness",
+      "name": "Top Level Dependency Freshness",
+      "message": "Out of the total 3 explicit dependencies defined in the package.json; 0 major versions out of date (0.00%), 0 minor versions out of date (0.00%), 0 patch versions out of date (0.00%)",
+      "actions": []
+    }
+  ]
+}

--- a/packages/pi-ui/graphql/resolvers.ts
+++ b/packages/pi-ui/graphql/resolvers.ts
@@ -1,0 +1,7 @@
+import report from './report.json';
+
+export const resolvers = {
+  Query: {
+    report: () => report,
+  },
+};

--- a/packages/pi-ui/graphql/schema.ts
+++ b/packages/pi-ui/graphql/schema.ts
@@ -1,0 +1,96 @@
+import { gql } from 'apollo-server-micro';
+
+export const typeDefs = gql`
+  type DependencyMap {
+    name: String
+    version: String
+  }
+
+  interface Package {
+    name: String
+    version: String
+    dependencies: [Package]
+    devDependencies: [Package]
+  }
+
+  type ArboristEdge {
+    name: String!
+    spec: String!
+    accept: String!
+    from: ArboristNode!
+    to: ArboristNode!
+  }
+
+  type ArboristNode {
+    dev: Boolean!
+    devOptional: Boolean!
+    dummy: Boolean!
+    extraneous: Boolean!
+    hasShrinkwrap: Boolean!
+    legacyPeerDeps: Boolean!
+    location: String!
+    name: String!
+    optional: Boolean!
+    path: String!
+    peer: String!
+    realpath: String!
+    package: Package!
+    packageName: String!
+    isLink: Boolean!
+    isWorkspace: Boolean!
+    homepage: String!
+    funding: String!
+    version: String!
+  }
+
+  type Dependency {
+    breadcrumb: String!
+    funding: String
+    homepage: String
+    location: String!
+    version: String!
+    name: String!
+    size: Float!
+  }
+
+  type ActionMeta {
+    breadcrumb: String!
+    name: String!
+    directory: String!
+    version: String!
+    size: Float
+  }
+
+  type VersionMeta {
+    version: String!
+  }
+
+  type Action {
+    message: String!
+    meta: ActionMeta!
+  }
+
+  type Suggestionnput {
+    rootArboristNode: ArboristNode
+    arboristValues: [ArboristNode!]!
+    latestPackages: [DependencyMap]
+  }
+
+  type Suggestion {
+    id: String!
+    name: String!
+    message: String!
+    actions: [Action!]!
+  }
+
+  type Report {
+    latestPackages: [DependencyMap]!
+    package: Package!
+    dependencies: [Package]
+    suggestions: [Suggestion!]!
+  }
+
+  type Query {
+    report: Report!
+  }
+`;

--- a/packages/pi-ui/package.json
+++ b/packages/pi-ui/package.json
@@ -2,6 +2,9 @@
   "name": "@package-inspector/pi-ui",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">= 16"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -9,16 +12,25 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "apollo-server-micro": "^3.6.7",
+    "graphql": "^16.4.0",
+    "micro": "^9.3.4",
+    "micro-cors": "^0.1.1",
     "next": "12.1.5",
     "react": "18.0.0",
     "react-dom": "18.0.0"
   },
   "devDependencies": {
+    "@types/micro-cors": "^0.1.2",
     "@types/node": "17.0.27",
     "@types/react": "18.0.6",
     "@types/react-dom": "18.0.0",
     "eslint": "8.14.0",
     "eslint-config-next": "12.1.5",
     "typescript": "4.6.3"
+  },
+  "volta": {
+    "node": "16.14.2",
+    "yarn": "1.22.10"
   }
 }

--- a/packages/pi-ui/pages/api/graphql.ts
+++ b/packages/pi-ui/pages/api/graphql.ts
@@ -1,0 +1,29 @@
+import { ApolloServer } from 'apollo-server-micro';
+import Cors from 'micro-cors';
+
+import { typeDefs } from '../../graphql/schema';
+import { resolvers } from '../../graphql/resolvers';
+
+const cors = Cors();
+
+const apolloServer = new ApolloServer({ typeDefs, resolvers });
+
+const startServer = apolloServer.start();
+
+export default cors(async function handler(req, res) {
+  if (req.method === 'OPTIONS') {
+    res.end();
+    return false;
+  }
+  await startServer;
+
+  await apolloServer.createHandler({
+    path: '/api/graphql',
+  })(req, res);
+});
+
+export const config = {
+  api: {
+    bodyParser: false,
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,37 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
+"@apollo/protobufjs@1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@apollo/protobufjs/-/protobufjs-1.2.2.tgz#4bd92cd7701ccaef6d517cdb75af2755f049f87c"
+  integrity sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.0"
+    "@types/node" "^10.1.0"
+    long "^4.0.0"
+
+"@apollographql/apollo-tools@^0.5.3":
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/@apollographql/apollo-tools/-/apollo-tools-0.5.3.tgz#ba241d50f0849150ca0de54fd2927160033bc0bc"
+  integrity sha512-VcsXHfTFoCodDAgJZxN04GdFK1kqOhZQnQY/9Fa147P+I8xfvOSz5d+lKAPB+hwSgBNyd7ncAKGIs4+utbL+yA==
+
+"@apollographql/graphql-playground-html@1.6.29":
+  version "1.6.29"
+  resolved "https://registry.yarnpkg.com/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.29.tgz#a7a646614a255f62e10dcf64a7f68ead41dec453"
+  integrity sha512-xCcXpoz52rI4ksJSdOCxeOCn2DLocxwHf9dVT/Q90Pte1LX+LY+91SFtJF3KXVHH8kEin+g1KKCQPKBjZJfWNA==
+  dependencies:
+    xss "^1.0.8"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
@@ -320,6 +351,61 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
+"@graphql-tools/merge@8.2.10":
+  version "8.2.10"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.2.10.tgz#fe2fe5ad33dc2d1b0af8751c0c08d18bb6bb6d88"
+  integrity sha512-wpg22seOTNfkIO8jFAgo8w1BsT3IS2OTMpkCNf+dvcKSP09SVidYCOliyWHgjDCmpCrvvSjOX855NUKDx/Biew==
+  dependencies:
+    "@graphql-tools/utils" "8.6.9"
+    tslib "~2.3.0"
+
+"@graphql-tools/mock@^8.1.2":
+  version "8.6.8"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/mock/-/mock-8.6.8.tgz#232a23c0c14dcfca88012886230b93e6fc2303e2"
+  integrity sha512-zBZApp8dDAovWKZ0rkZ4CwDT8Z+B35pIyRjeHkxvtKt5XyEAabEwkuSYMyFdsghDWwhMD/VAZ/6DXtA62Hnf+A==
+  dependencies:
+    "@graphql-tools/schema" "8.3.10"
+    "@graphql-tools/utils" "8.6.9"
+    fast-json-stable-stringify "^2.1.0"
+    tslib "~2.3.0"
+
+"@graphql-tools/schema@8.3.10", "@graphql-tools/schema@^8.0.0":
+  version "8.3.10"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-8.3.10.tgz#c3e373e6ad854f533fc7e55859dd8f9e81de30dd"
+  integrity sha512-tfhjSTi3OzheDrVzG7rkPZg2BbQjmZRLM2vvQoM2b1TnUwgUIbpAgcnf+AWDLRsoCOWlezeLgij1BLeAR0Q0jg==
+  dependencies:
+    "@graphql-tools/merge" "8.2.10"
+    "@graphql-tools/utils" "8.6.9"
+    tslib "~2.3.0"
+    value-or-promise "1.0.11"
+
+"@graphql-tools/utils@8.6.9":
+  version "8.6.9"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-8.6.9.tgz#fe1b81df29c9418b41b7a1ffe731710b93d3a1fe"
+  integrity sha512-Z1X4d4GCT81+8CSt6SgU4t1w1UAUsAIRb67mI90k/zAs+ArkB95iE3bWXuJCUmd1+r8DGGtmUNOArtd6wkt+OQ==
+  dependencies:
+    tslib "~2.3.0"
+
+"@hapi/accept@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@hapi/accept/-/accept-5.0.2.tgz#ab7043b037e68b722f93f376afb05e85c0699523"
+  integrity sha512-CmzBx/bXUR8451fnZRuZAJRlzgm0Jgu5dltTX/bszmR2lheb9BpyN47Q1RbaGTsvFzn0PXAEs+lXDKfshccYZw==
+  dependencies:
+    "@hapi/boom" "9.x.x"
+    "@hapi/hoek" "9.x.x"
+
+"@hapi/boom@9.x.x":
+  version "9.1.4"
+  resolved "https://registry.yarnpkg.com/@hapi/boom/-/boom-9.1.4.tgz#1f9dad367c6a7da9f8def24b4a986fc5a7bd9db6"
+  integrity sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==
+  dependencies:
+    "@hapi/hoek" "9.x.x"
+
+"@hapi/hoek@9.x.x":
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.1.tgz#9551142a1980503752536b5050fd99f4a7f13b17"
+  integrity sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==
+
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.5.tgz#2cbaf9a89460da24b5ca6531b8bbfc23e1df50c7"
@@ -523,6 +609,11 @@
     "@types/node" "*"
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
+
+"@josephg/resolvable@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@josephg/resolvable/-/resolvable-1.0.1.tgz#69bc4db754d79e1a2f17a650d3466e038d94a5eb"
+  integrity sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg==
 
 "@jridgewell/resolve-uri@^3.0.3":
   version "3.0.6"
@@ -768,6 +859,59 @@
     node-gyp "^9.0.0"
     read-package-json-fast "^2.0.3"
 
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+  integrity sha1-m4sMxmPWaafY9vXQiToU00jzD78=
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
+
+"@protobufjs/codegen@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
+  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
+
+"@protobufjs/eventemitter@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
+  integrity sha1-NVy8mLr61ZePntCV85diHx0Ga3A=
+
+"@protobufjs/fetch@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
+  integrity sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+    "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+  integrity sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=
+
+"@protobufjs/inquire@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+  integrity sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+  integrity sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+  integrity sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=
+
+"@protobufjs/utf8@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
+  integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
+
 "@rushstack/eslint-patch@1.0.8":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.0.8.tgz#be3e914e84eacf16dbebd311c0d0b44aa1174c64"
@@ -881,6 +1025,25 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/long@^4.0.0":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
+  integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
+
+"@types/micro-cors@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@types/micro-cors/-/micro-cors-0.1.2.tgz#3004f5935d06b6f03016aa5975e8851e803d8374"
+  integrity sha512-dlNOHHaatKcuYXGMHkqICtFdthd+3tE8pFIrDTbDBYAtlTb7HzYh+NeEgfNWiARgOnsIOuoh2L2XR4UHow84nw==
+  dependencies:
+    "@types/micro" "*"
+
+"@types/micro@*":
+  version "7.3.7"
+  resolved "https://registry.yarnpkg.com/@types/micro/-/micro-7.3.7.tgz#84bef63ef8cc113a70b9a64345ebea2d99946647"
+  integrity sha512-MFsX7eCj0Tg3TtphOQvANNvNtFpya+s/rYOCdV6o+DFjOQPFi2EVRbBALjbbgZTXUaJP1Q281MJiJOD40d0UxQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/ms@*":
   version "0.7.31"
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
@@ -890,6 +1053,11 @@
   version "17.0.27"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.27.tgz#f4df3981ae8268c066e8f49995639f855469081e"
   integrity sha512-4/Ke7bbWOasuT3kceBZFGakP1dYN2XFd8v2l9bqF2LNWrmeU07JLpp56aEeG6+Q3olqO5TvXpW0yaiYnZJ5CXg==
+
+"@types/node@^10.1.0":
+  version "10.17.60"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
+  integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
 
 "@types/prettier@^2.1.5":
   version "2.6.0"
@@ -1194,6 +1362,92 @@ anymatch@^3.0.3:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+apollo-datasource@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/apollo-datasource/-/apollo-datasource-3.3.1.tgz#a1168dd68371930de3ed4245ad12fa8600efe2cc"
+  integrity sha512-Z3a8rEUXVPIZ1p8xrFL8bcNhWmhOmovgDArvwIwmJOBnh093ZpRfO+ESJEDAN4KswmyzCLDAwjsW4zQOONdRUw==
+  dependencies:
+    apollo-server-caching "^3.3.0"
+    apollo-server-env "^4.2.1"
+
+apollo-reporting-protobuf@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/apollo-reporting-protobuf/-/apollo-reporting-protobuf-3.3.1.tgz#8c8761f9ac4375fd8490262d6144057cec6ce0b3"
+  integrity sha512-tyvj3Vj71TCh6c8PtdHOLgHHBSJ05DF/A/Po3q8yfHTBkOPcOJZE/GGN/PT/pwKg7HHxKcAeHDw7+xciVvGx0w==
+  dependencies:
+    "@apollo/protobufjs" "1.2.2"
+
+apollo-server-caching@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-caching/-/apollo-server-caching-3.3.0.tgz#f501cbeb820a4201d98c2b768c085f22848d9dc5"
+  integrity sha512-Wgcb0ArjZ5DjQ7ID+tvxUcZ7Yxdbk5l1MxZL8D8gkyjooOkhPNzjRVQ7ubPoXqO54PrOMOTm1ejVhsF+AfIirQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
+apollo-server-core@^3.6.7:
+  version "3.6.7"
+  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-3.6.7.tgz#6a52ce48fe1a79da9691c3fff4ea1031e9225602"
+  integrity sha512-OnZ9vu7LrYy2rvEu+nbgqucw6VyTSIPAEjK87c4rkzlVOxpwtGUaQ4FMWD9zBIj7yLq9q22b638E8LdYoaTAjQ==
+  dependencies:
+    "@apollographql/apollo-tools" "^0.5.3"
+    "@apollographql/graphql-playground-html" "1.6.29"
+    "@graphql-tools/mock" "^8.1.2"
+    "@graphql-tools/schema" "^8.0.0"
+    "@josephg/resolvable" "^1.0.0"
+    apollo-datasource "^3.3.1"
+    apollo-reporting-protobuf "^3.3.1"
+    apollo-server-caching "^3.3.0"
+    apollo-server-env "^4.2.1"
+    apollo-server-errors "^3.3.1"
+    apollo-server-plugin-base "^3.5.2"
+    apollo-server-types "^3.5.2"
+    async-retry "^1.2.1"
+    fast-json-stable-stringify "^2.1.0"
+    graphql-tag "^2.11.0"
+    lodash.sortby "^4.7.0"
+    loglevel "^1.6.8"
+    lru-cache "^6.0.0"
+    sha.js "^2.4.11"
+    uuid "^8.0.0"
+
+apollo-server-env@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/apollo-server-env/-/apollo-server-env-4.2.1.tgz#ea5b1944accdbdba311f179e4dfaeca482c20185"
+  integrity sha512-vm/7c7ld+zFMxibzqZ7SSa5tBENc4B0uye9LTfjJwGoQFY5xsUPH5FpO5j0bMUDZ8YYNbrF9SNtzc5Cngcr90g==
+  dependencies:
+    node-fetch "^2.6.7"
+
+apollo-server-errors@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/apollo-server-errors/-/apollo-server-errors-3.3.1.tgz#ba5c00cdaa33d4cbd09779f8cb6f47475d1cd655"
+  integrity sha512-xnZJ5QWs6FixHICXHxUfm+ZWqqxrNuPlQ+kj5m6RtEgIpekOPssH/SD9gf2B4HuWV0QozorrygwZnux8POvyPA==
+
+apollo-server-micro@^3.6.7:
+  version "3.6.7"
+  resolved "https://registry.yarnpkg.com/apollo-server-micro/-/apollo-server-micro-3.6.7.tgz#c22779c579a9de48d2891fda460f013fb49f66a6"
+  integrity sha512-qja7iWsuagvVUdw6PsysVucDQR5+DnHNdWbH+u/0OQnZQK3Qlra7CvTHH+8P6T1F5LJ+iaZreLqrMQeihivQmw==
+  dependencies:
+    "@hapi/accept" "^5.0.2"
+    apollo-server-core "^3.6.7"
+    apollo-server-types "^3.5.2"
+    type-is "^1.6.18"
+
+apollo-server-plugin-base@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/apollo-server-plugin-base/-/apollo-server-plugin-base-3.5.2.tgz#18a08353f5ea207a07f2c1e66dd7ef2335ce8c84"
+  integrity sha512-SwIf1waDmNDb0kmn57QR++InwK6Iv/X2slpm/aFIoqFBe91r6uJfakJvQZuh8dLEgk68gxqFsT8zHRpxBclE+g==
+  dependencies:
+    apollo-server-types "^3.5.2"
+
+apollo-server-types@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/apollo-server-types/-/apollo-server-types-3.5.2.tgz#903d499a70b9010764cbab4d704ddb8c086aa06f"
+  integrity sha512-vhcbIWsBkoNibABOym4AAPBoNDjokhjUQokKYdwZMeqrb850PMQdNJFrGyXT5onP408Ghv4O8PfgBuPQmeJhVQ==
+  dependencies:
+    apollo-reporting-protobuf "^3.3.1"
+    apollo-server-caching "^3.3.0"
+    apollo-server-env "^4.2.1"
+
 "aproba@^1.0.3 || ^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
@@ -1206,6 +1460,11 @@ are-we-there-yet@^3.0.0:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^3.6.0"
+
+arg@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.0.tgz#583c518199419e0037abb74062c37f8519e575f0"
+  integrity sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -1277,6 +1536,13 @@ astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
+
+async-retry@^1.2.1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.3.tgz#0e7f36c04d8478e7a58bdbed80cedf977785f280"
+  integrity sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==
+  dependencies:
+    retry "0.13.1"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -1449,6 +1715,11 @@ builtins@^5.0.0:
   integrity sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==
   dependencies:
     semver "^7.0.0"
+
+bytes@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
+  integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
 
 cacache@^16.0.0, cacache@^16.0.2:
   version "16.0.6"
@@ -1649,6 +1920,11 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^2.20.3:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 commander@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
@@ -1668,6 +1944,11 @@ console-control-strings@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
+
+content-type@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
+  integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
 convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.8.0"
@@ -1689,6 +1970,11 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+cssfilter@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/cssfilter/-/cssfilter-0.0.10.tgz#c6d2672632a2e5c83e013e6864a42ce8defd20ae"
+  integrity sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4=
 
 cssom@^0.4.4:
   version "0.4.4"
@@ -1796,6 +2082,11 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+
+depd@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
+  integrity sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=
 
 depd@^1.1.2:
   version "1.1.2"
@@ -2246,7 +2537,7 @@ fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -2483,6 +2774,18 @@ graceful-fs@^4.1.2, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
+graphql-tag@^2.11.0:
+  version "2.12.6"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
+  integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
+  dependencies:
+    tslib "^2.1.0"
+
+graphql@^16.4.0:
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.4.0.tgz#bb10b1b4683045dedcb67000eb4ad134a36c59e6"
+  integrity sha512-tYDNcRvKCcfHREZYje3v33NSrSD/ZpbWWdPtBtUUuXx9NCo/2QDxYzNqCnMvfsrnbwRpEHMovVrPu/ERoLrIRg==
+
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
@@ -2553,6 +2856,16 @@ http-cache-semantics@^4.1.0:
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
   integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
 
+http-errors@1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
+  integrity sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=
+  dependencies:
+    depd "1.1.1"
+    inherits "2.0.3"
+    setprototypeof "1.0.3"
+    statuses ">= 1.3.1 < 2"
+
 http-proxy-agent@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a"
@@ -2595,6 +2908,11 @@ husky@^7.0.4:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.4.tgz#242048245dc49c8fb1bf0cc7cfb98dd722531535"
   integrity sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==
+
+iconv-lite@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+  integrity sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==
 
 iconv-lite@0.4.24:
   version "0.4.24"
@@ -2666,10 +2984,15 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@^2.0.4:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+inherits@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+  integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
 internal-slot@^1.0.3:
   version "1.0.3"
@@ -2797,6 +3120,11 @@ is-shared-array-buffer@^1.0.2:
   integrity sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==
   dependencies:
     call-bind "^1.0.2"
+
+is-stream@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+  integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
 
 is-stream@^2.0.0:
   version "2.0.1"
@@ -3501,6 +3829,11 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
+lodash.sortby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+  integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
+
 lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
@@ -3523,6 +3856,16 @@ log-update@^4.0.0:
     cli-cursor "^3.1.0"
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
+
+loglevel@^1.6.8:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.8.0.tgz#e7ec73a57e1e7b419cb6c6ac06bf050b67356114"
+  integrity sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==
+
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
@@ -3579,6 +3922,11 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
+media-typer@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+  integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -3588,6 +3936,21 @@ merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+micro-cors@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/micro-cors/-/micro-cors-0.1.1.tgz#af7a480182c114ffd1ada84ad9dffc52bb4f4054"
+  integrity sha512-6WqIahA5sbQR1Gjexp1VuWGFDKbZZleJb/gy1khNGk18a6iN1FdTcr3Q8twaxkV5H94RjxIBjirYbWCehpMBFw==
+
+micro@^9.3.4:
+  version "9.3.4"
+  resolved "https://registry.yarnpkg.com/micro/-/micro-9.3.4.tgz#745a494e53c8916f64fb6a729f8cbf2a506b35ad"
+  integrity sha512-smz9naZwTG7qaFnEZ2vn248YZq9XR+XoOH3auieZbkhDL4xLOxiE+KqG8qqnBeKfXA9c1uEFGCxPN1D+nT6N7w==
+  dependencies:
+    arg "4.1.0"
+    content-type "1.0.4"
+    is-stream "1.1.0"
+    raw-body "2.3.2"
 
 micromatch@^4.0.4:
   version "4.0.5"
@@ -3602,7 +3965,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.12:
+mime-types@^2.1.12, mime-types@~2.1.24:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -3761,6 +4124,13 @@ next@12.1.5:
     "@next/swc-win32-arm64-msvc" "12.1.5"
     "@next/swc-win32-ia32-msvc" "12.1.5"
     "@next/swc-win32-x64-msvc" "12.1.5"
+
+node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-gyp@^9.0.0:
   version "9.0.0"
@@ -4264,6 +4634,16 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+raw-body@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.2.tgz#bcd60c77d3eb93cde0050295c3f379389bc88f89"
+  integrity sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=
+  dependencies:
+    bytes "3.0.0"
+    http-errors "1.6.2"
+    iconv-lite "0.4.19"
+    unpipe "1.0.0"
+
 react-dom@18.0.0:
   version "18.0.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.0.0.tgz#26b88534f8f1dbb80853e1eabe752f24100d8023"
@@ -4402,6 +4782,11 @@ restore-cursor@^3.1.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
 
+retry@0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
+
 retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
@@ -4438,15 +4823,15 @@ rxjs@^7.5.5:
   dependencies:
     tslib "^2.1.0"
 
+safe-buffer@^5.0.1, safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
 safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
-
-safe-buffer@~5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 "safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"
@@ -4483,6 +4868,19 @@ set-blocking@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+setprototypeof@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
+  integrity sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=
+
+sha.js@^2.4.11:
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
+  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -4640,6 +5038,11 @@ stack-utils@^2.0.3:
   integrity sha512-xrQcmYhOsn/1kX+Vraq+7j4oE2j/6BFscZ0etmYg81xuM8Gq0022Pxb8+IqgOFUIaxHs0KaSb7T1+OegiNrNFA==
   dependencies:
     escape-string-regexp "^2.0.0"
+
+"statuses@>= 1.3.1 < 2":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
+  integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
 string-argv@^0.3.1:
   version "0.3.1"
@@ -4876,6 +5279,11 @@ tr46@^2.1.0:
   dependencies:
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 treeverse@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/treeverse/-/treeverse-2.0.0.tgz#036dcef04bc3fd79a9b79a68d4da03e882d8a9ca"
@@ -4900,6 +5308,11 @@ tslib@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
+tslib@~2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -4936,6 +5349,14 @@ type-fest@^0.21.3:
   version "0.21.3"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
+
+type-is@^1.6.18:
+  version "1.6.18"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
+  integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
+  dependencies:
+    media-typer "0.3.0"
+    mime-types "~2.1.24"
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
@@ -4978,6 +5399,11 @@ universalify@^0.1.2:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
+unpipe@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+  integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
+
 uri-js@^4.2.2:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
@@ -4989,6 +5415,11 @@ util-deprecate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
+uuid@^8.0.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"
@@ -5018,6 +5449,11 @@ validate-npm-package-name@^4.0.0:
   integrity sha512-mzR0L8ZDktZjpX4OB46KT+56MAhl4EIazWP/+G/HPGuvfdaqg4YsCdtOm6U9+LOFyYDoh4dpnpxZRB9MQQns5Q==
   dependencies:
     builtins "^5.0.0"
+
+value-or-promise@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/value-or-promise/-/value-or-promise-1.0.11.tgz#3e90299af31dd014fe843fe309cefa7c1d94b140"
+  integrity sha512-41BrgH+dIbCFXClcSapVs5M6GkENd3gQOJpEfPDNa71LsUGMXDL0jMWpI/Rh7WhX+Aalfz2TTS3Zt5pUsbnhLg==
 
 w3c-hr-time@^1.0.2:
   version "1.0.2"
@@ -5052,6 +5488,11 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
@@ -5073,6 +5514,14 @@ whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^8.0.0, whatwg-url@^8.5.0:
   version "8.7.0"
@@ -5168,6 +5617,14 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xss@^1.0.8:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/xss/-/xss-1.0.11.tgz#211cb82e95b5071d4c75d597283c021157ebe46a"
+  integrity sha512-EimjrjThZeK2MO7WKR9mN5ZC1CSqivSl55wvUK5EtU6acf0rzEE1pN+9ZDrFXJ82BRp3JL38pPE6S4o/rpp1zQ==
+  dependencies:
+    commander "^2.20.3"
+    cssfilter "0.0.10"
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
fixes #4 

When running `npm run dev` or `yarn dev` in `pi-ui` you automatically get an apollo studio setup that will serve the results of a static report.json

![Screen Shot 2022-04-25 at 1 56 40 PM](https://user-images.githubusercontent.com/1854811/165173739-dab711dd-2c4d-4379-8ef0-9fbfe0bbae9d.png)
