### PR TITLE
feat: if the output path contains .json don't add report.json

### DIFF
--- a/packages/pi-cli/src/bin/index.ts
+++ b/packages/pi-cli/src/bin/index.ts
@@ -23,7 +23,7 @@ const { argv } = yargs
       default: process.cwd(),
       type: 'string',
     },
-    outputDir: {
+    output: {
       describe: 'The path to output report to',
       default: path.resolve(process.cwd(), 'report'),
       type: 'string',
@@ -40,13 +40,13 @@ const changeStatus = (text: string) =>
   (progress.text = `(${getHrTimeInSeconds(start)}) - ${text}`);
 
 const cwd = path.resolve(process.cwd(), argv.path);
-const outputDir = path.resolve(argv.outputDir);
+const reportPath = argv.output.indexOf('.json')
+  ? path.resolve(argv.output)
+  : path.resolve(argv.output, 'report.json');
 
 (async function main() {
   try {
     const report = await generateReport(cwd);
-
-    const reportPath = path.resolve(outputDir, 'report.json');
 
     try {
       fs.mkdirSync(path.dirname(reportPath), { recursive: true });


### PR DESCRIPTION
Makes it possible to run with an output to a direct file. It will default to report.json if the path is a directory

```shell
./packages/pi-cli/bin/index.js --path /Users/gcsapo/Documents/docusaurus-plugin-search-local --output /Users/gcsapo/Documents/package-inspector/packages/pi-ui/__fixtures__/reports/docusaurus-plugin-search-local.json
```