### PR TITLE
refactor: using BFS to explore the dependency graph

### DIFF
--- a/packages/core/src/models/Package.ts
+++ b/packages/core/src/models/Package.ts
@@ -1,0 +1,83 @@
+import path from 'path';
+import { getDirectorySize, stripPathOnDisk } from '../package';
+
+export interface ISizeInfo {
+  files: number;
+  physical: number;
+}
+
+export interface IPackageMetadata {
+  size?: ISizeInfo;
+  pathsOnDisk: string[];
+}
+
+export interface IPackage {
+  name: string;
+  version: string;
+  metadata?: IPackageMetadata;
+  funding?: string;
+  homepage?: string;
+  dependencies: string[];
+  type?: string;
+}
+
+export interface PackageOptions {
+  name: string;
+  path: string;
+  rootPath: string;
+  version: string;
+  funding?: string;
+  homepage?: string;
+  type?: string;
+}
+
+export class Package {
+  /**
+   * A list of package keys that this package depends on.
+   */
+  dependencies: string[] = [];
+
+  metadata: IPackageMetadata;
+  name: string;
+  path: string;
+  version: string;
+  rootPath: string;
+
+  funding?: string;
+  homepage?: string;
+  type?: string;
+
+  constructor(options: PackageOptions) {
+    // Required fields
+    this.name = options.name;
+    this.path = options.path; // TODO: why do we have a path ont he package and in the metadata?
+    this.version = options.version;
+    this.rootPath = options.rootPath;
+
+    // Optional fields
+    this.funding = options.funding;
+    this.homepage = options.homepage;
+    this.type = options.type;
+
+    // TODO: maybe make this lazy?
+    this.metadata = {
+      size: getDirectorySize({
+        directory: this.path,
+        exclude: new RegExp(path.resolve(this.path, 'node_modules')),
+      }),
+      pathsOnDisk: [stripPathOnDisk(this.path, this.rootPath)],
+    };
+  }
+
+  addDependency(dependency: string) {
+    this.dependencies.push(dependency);
+  }
+
+  addPath(pathOnDisk: string) {
+    const strippedPath = stripPathOnDisk(pathOnDisk, this.rootPath);
+
+    if (!this.metadata.pathsOnDisk.includes(strippedPath)) {
+      this.metadata.pathsOnDisk.push(strippedPath);
+    }
+  }
+}

--- a/packages/core/src/models/Report.ts
+++ b/packages/core/src/models/Report.ts
@@ -1,28 +1,10 @@
 import fs from 'fs-extra';
+import { IPackage } from './Package';
 
 export type LatestPackages = Record<string, string>;
-export interface SizeInfo {
-  files: number;
-  physical: number;
-}
-
-export interface PackageMetadata {
-  size?: SizeInfo;
-  pathsOnDisk: string[];
-}
 
 export interface DependenciesMap {
-  [dependencyName: string]: Package;
-}
-
-export interface Package {
-  name: string;
-  version: string;
-  metadata?: PackageMetadata;
-  funding?: string;
-  homepage?: string;
-  dependencies: string[];
-  type?: string;
+  [dependencyName: string]: IPackage;
 }
 
 export interface SuggestionMap {
@@ -149,7 +131,7 @@ export function serializeReport(jsonReport: any): SerializedReport {
 }
 
 export class Report {
-  root: Package;
+  root: IPackage;
 
   latestPackages: LatestPackages = {};
   dependencies: DependenciesMap = {};

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -1,1 +1,2 @@
+export * from './Package';
 export * from './Report';

--- a/packages/core/src/report/generate-report.ts
+++ b/packages/core/src/report/generate-report.ts
@@ -1,14 +1,17 @@
 import path from 'path';
 import Arborist from '@npmcli/arborist';
+import createDebug from 'debug';
 
-import { IArboristNode, ServerPlugin } from '../types';
+const logger = createDebug('pi-core:generate-report');
+
+import { IArboristEdge, IArboristNode, ServerPlugin } from '../types';
 import {
   getDirectorySize,
   getLatestPackages,
   stripPathOnDisk,
 } from '../package';
 
-import { Report, Suggestion } from '../models';
+import { Package, Report, Suggestion } from '../models';
 
 function getValues(dependencyTree: IArboristNode) {
   // ignore the root node
@@ -53,8 +56,69 @@ export async function generateReport(
   });
 
   const rootArboristNode: IArboristNode = await arb.loadActual();
+
+  // Exploring the dependency graph via BFS
+  const depNodeMap = new Map<string, Package>();
+  const edgeQueue: IArboristEdge[] = [...rootArboristNode.edgesOut.values()];
+  const visited = new Set<string>();
+
+  while (edgeQueue.length > 0) {
+    const { to: node, type } = edgeQueue.shift()!; // will always have a value given our while loop condition.
+
+    // TODO: `to` may possible be empty, in the case of a `peer` or `optional` dependency, may be able to determine this by the type of the edge.
+    // TODO: update the arborist type to make to optional based on the above comment
+
+    const lookupKey = `${node.name}@${node.version}`;
+
+    if (visited.has(lookupKey)) {
+      logger(`Skipping node: ${lookupKey}`);
+
+      const existingNode = depNodeMap.get(lookupKey);
+
+      if (existingNode) {
+        existingNode.addPath(node.path);
+
+        if (existingNode.type !== type) {
+          // This is a case where we already processed the dependency, but the type is different than the original type.
+          // This can happen if two packages depend on this package, but the type is different (i.e. peer vs optional vs prod).
+          // TODO: we need to handle "upleveling" of the type, i.e. dev -> optional -> peer -> prod.
+          logger(
+            `Type mismatch for node: ${lookupKey} -- Existing: ${existingNode?.type} -- Current: ${type}`
+          );
+        }
+      }
+
+      continue;
+    }
+
+    logger(`Exploring node: ${lookupKey}`);
+
+    const pkg = new Package({
+      name: node.name,
+      path: node.path,
+      rootPath: cwd,
+      version: node.version,
+      funding: node.funding,
+      homepage: node.homepage,
+      type: type,
+    });
+
+    for (const edgeOut of node.edgesOut.values()) {
+      // Add edge destinations to the queue.
+      edgeQueue.push(edgeOut);
+
+      // Add the edge's dependency to the package.
+      pkg.addDependency(`${edgeOut.to.name}@${edgeOut.to.version}`);
+    }
+
+    // Add this node to the visited set.
+    visited.add(lookupKey);
+    depNodeMap.set(lookupKey, pkg);
+  }
+
   const arboristValues = getValues(rootArboristNode);
 
+  // TODO: refactor this as well.
   const latestPackagesMap = await getLatestPackages(arboristValues);
 
   Object.keys(latestPackagesMap).forEach((packageName) => {


### PR DESCRIPTION
## Summary

This PR is shifting how we traverse the dependency graph to fully explore the graph and build out the report.

