### PR TITLE
refactor: use a root Layout component

### DIFF
--- a/packages/ui/components/ErrorView.tsx
+++ b/packages/ui/components/ErrorView.tsx
@@ -3,10 +3,9 @@ import * as React from 'react';
 import styles from './ErrorView.module.css';
 
 interface ErrorViewProps {
-  title: string;
   message: string;
 }
 
-export const ErrorView: React.FC<ErrorViewProps> = ({ title, message }) => {
+export const ErrorView: React.FC<ErrorViewProps> = ({ message }) => {
   return <div className={styles.errorContainer}>{message}</div>;
 };

--- a/packages/ui/components/ErrorView.tsx
+++ b/packages/ui/components/ErrorView.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 
-import { Layout } from './';
 import styles from './ErrorView.module.css';
 
 interface ErrorViewProps {
@@ -9,9 +8,5 @@ interface ErrorViewProps {
 }
 
 export const ErrorView: React.FC<ErrorViewProps> = ({ title, message }) => {
-  return (
-    <Layout title={title}>
-      <div className={styles.errorContainer}>{message}</div>
-    </Layout>
-  );
+  return <div className={styles.errorContainer}>{message}</div>;
 };

--- a/packages/ui/components/Layout.tsx
+++ b/packages/ui/components/Layout.tsx
@@ -7,11 +7,14 @@ import Navbar from '../components/Navbar';
 import styles from './Layout.module.css';
 
 type LayoutProps = React.PropsWithChildren<{
-  title: string;
   hero?: React.FC;
 }>;
 
-export const Layout: React.FC<LayoutProps> = ({ title, hero, children }) => {
+const MAIN_CONTAINER_SX_OPTIONS = { py: 8, backgroundColor: 'grey.100' };
+
+export const Layout: React.FC<LayoutProps> = ({ hero, children }) => {
+  const Hero = hero || null;
+
   return (
     <>
       <Head>
@@ -20,11 +23,11 @@ export const Layout: React.FC<LayoutProps> = ({ title, hero, children }) => {
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
-      <Navbar title={title} />
+      <Navbar />
 
-      {hero ? hero : null}
+      {Hero && <Hero />}
 
-      <Container sx={{ py: 8, backgroundColor: 'grey.100' }} maxWidth={false}>
+      <Container sx={MAIN_CONTAINER_SX_OPTIONS} maxWidth={false}>
         {children}
       </Container>
 

--- a/packages/ui/components/Navbar.tsx
+++ b/packages/ui/components/Navbar.tsx
@@ -1,3 +1,4 @@
+import { gql, useQuery } from '@apollo/client';
 import MenuIcon from '@mui/icons-material/Menu';
 import {
   AppBar,
@@ -16,8 +17,24 @@ import * as React from 'react';
 
 import { PluginProvider } from '../lib/PluginProvider';
 
-const ResponsiveAppBar = ({ title }: { title: string }) => {
+const TitleQuery = gql`
+  query TitleQuery {
+    title
+  }
+`;
+
+interface TitleData {
+  title: string;
+}
+
+interface NavBarProps {
+  title?: string;
+}
+
+const NavBar: React.FC<NavBarProps> = (props) => {
   const pluginProvider = new PluginProvider();
+
+  const { data } = useQuery<TitleData>(TitleQuery);
 
   const [anchorElNav, setAnchorElNav] = React.useState<null | HTMLElement>(
     null
@@ -52,7 +69,7 @@ const ResponsiveAppBar = ({ title }: { title: string }) => {
               sx={{ mr: 2, display: { xs: 'none', md: 'flex' } }}
             >
               <Button sx={{ my: 2, color: 'white', display: 'block' }}>
-                {title}
+                {props.title || data?.title || '...'}
               </Button>
             </Typography>
           </NextLink>
@@ -106,7 +123,7 @@ const ResponsiveAppBar = ({ title }: { title: string }) => {
               sx={{ flexGrow: 1, display: { xs: 'flex', md: 'none' } }}
             >
               <Button sx={{ my: 2, color: 'white', display: 'block' }}>
-                {title}
+                {props.title || data?.title || '...'}
               </Button>
             </Typography>
           </NextLink>
@@ -161,4 +178,4 @@ const ResponsiveAppBar = ({ title }: { title: string }) => {
     </AppBar>
   );
 };
-export default ResponsiveAppBar;
+export default NavBar;

--- a/packages/ui/graphql/generated/nexus-typegen.ts
+++ b/packages/ui/graphql/generated/nexus-typegen.ts
@@ -122,6 +122,7 @@ export interface NexusGenFieldTypes {
     packages: Array<NexusGenRootTypes['Package'] | null>; // [Package]!
     report: NexusGenRootTypes['Report']; // Report!
     suggestion: NexusGenRootTypes['Suggestion'] | null; // Suggestion
+    title: string; // String!
   };
   Report: {
     // field return type
@@ -197,6 +198,7 @@ export interface NexusGenFieldTypeNames {
     packages: 'Package';
     report: 'Report';
     suggestion: 'Suggestion';
+    title: 'String';
   };
   Report: {
     // field return type name

--- a/packages/ui/graphql/generated/schema.graphql
+++ b/packages/ui/graphql/generated/schema.graphql
@@ -36,6 +36,7 @@ type Query {
   packages: [Package]!
   report: Report!
   suggestion(id: String!): Suggestion
+  title: String!
 }
 
 type Report {

--- a/packages/ui/graphql/types/Report.ts
+++ b/packages/ui/graphql/types/Report.ts
@@ -139,3 +139,14 @@ export const ReportQuery = extendType({
     });
   },
 });
+
+export const TitleQuery = extendType({
+  type: 'Query',
+  definition(t) {
+    t.nonNull.string('title', {
+      resolve(_, __, ctx) {
+        return ctx.report.root.name;
+      },
+    });
+  },
+});

--- a/packages/ui/next-types.ts
+++ b/packages/ui/next-types.ts
@@ -1,5 +1,6 @@
-import { NextPage } from 'next';
+import type { NextPage } from 'next';
+import type { ReactElement, ReactNode } from 'react';
 
 export type NextPageWithLayout = NextPage & {
-  getLayout?: (page: React.ReactElement) => React.ReactNode;
+  getLayout?: (page: ReactElement) => ReactNode;
 };

--- a/packages/ui/next-types.ts
+++ b/packages/ui/next-types.ts
@@ -1,0 +1,5 @@
+import { NextPage } from 'next';
+
+export type NextPageWithLayout = NextPage & {
+  getLayout?: (page: React.ReactElement) => React.ReactNode;
+};

--- a/packages/ui/pages/_app.tsx
+++ b/packages/ui/pages/_app.tsx
@@ -5,22 +5,18 @@ import { EmotionCache } from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
-import { NextPage } from 'next';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import * as React from 'react';
 
 import { Layout } from '../components';
 import apolloClient from '../lib/apollo';
+import { NextPageWithLayout } from '../next-types';
 import createEmotionCache from '../styles/createEmotionCache';
 import theme from '../styles/theme';
 
 // Client-side cache, shared for the whole session of the user in the browser.
 const clientSideEmotionCache = createEmotionCache();
-
-type NextPageWithLayout = NextPage & {
-  getLayout?: (page: React.ReactElement) => React.ReactNode;
-};
 
 type AppPropsWithLayout = AppProps & {
   Component: NextPageWithLayout;

--- a/packages/ui/pages/_app.tsx
+++ b/packages/ui/pages/_app.tsx
@@ -5,10 +5,12 @@ import { EmotionCache } from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import CssBaseline from '@mui/material/CssBaseline';
 import { ThemeProvider } from '@mui/material/styles';
+import { NextPage } from 'next';
 import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import * as React from 'react';
 
+import { Layout } from '../components';
 import apolloClient from '../lib/apollo';
 import createEmotionCache from '../styles/createEmotionCache';
 import theme from '../styles/theme';
@@ -16,12 +18,20 @@ import theme from '../styles/theme';
 // Client-side cache, shared for the whole session of the user in the browser.
 const clientSideEmotionCache = createEmotionCache();
 
-export interface MyAppProps extends AppProps {
-  emotionCache: EmotionCache;
-}
+type NextPageWithLayout = NextPage & {
+  getLayout?: (page: React.ReactElement) => React.ReactNode;
+};
 
-export default function MyApp(props: MyAppProps) {
+type AppPropsWithLayout = AppProps & {
+  Component: NextPageWithLayout;
+  emotionCache: EmotionCache;
+};
+
+export default function MyApp(props: AppPropsWithLayout) {
   const { Component, emotionCache = clientSideEmotionCache, pageProps } = props;
+
+  // Use the layout defined at the page level, if available
+  const getLayout = Component.getLayout ?? ((page) => <Layout>{page}</Layout>);
 
   return (
     <ApolloProvider client={apolloClient}>
@@ -32,7 +42,7 @@ export default function MyApp(props: MyAppProps) {
         <ThemeProvider theme={theme}>
           {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
           <CssBaseline />
-          <Component {...pageProps} />
+          {getLayout(<Component {...pageProps} />)}
         </ThemeProvider>
       </CacheProvider>
     </ApolloProvider>

--- a/packages/ui/pages/_app.tsx
+++ b/packages/ui/pages/_app.tsx
@@ -9,7 +9,7 @@ import type { AppProps } from 'next/app';
 import Head from 'next/head';
 import * as React from 'react';
 
-import { Layout } from '../components';
+import { Layout } from '../components/Layout';
 import apolloClient from '../lib/apollo';
 import { NextPageWithLayout } from '../next-types';
 import createEmotionCache from '../styles/createEmotionCache';

--- a/packages/ui/pages/details.tsx
+++ b/packages/ui/pages/details.tsx
@@ -14,7 +14,7 @@ import { ResponsiveTreeMap } from '@nivo/treemap';
 import type { NextPage } from 'next';
 import NextLink from 'next/link';
 
-import { Layout, LoadingView } from '../components';
+import { LoadingView } from '../components';
 import { NexusGenFieldTypes } from '../graphql/generated/nexus-typegen';
 interface ReportData {
   report: Pick<NexusGenFieldTypes['Report'], 'summary'> & {
@@ -72,7 +72,7 @@ const Report: NextPage = () => {
   const nivoContainerStyles = { height: '300px' };
 
   return (
-    <Layout title={data.report.root.name}>
+    <>
       <h1> Details </h1>
 
       <h2>Dependency Map:</h2>
@@ -143,7 +143,7 @@ const Report: NextPage = () => {
           </TableBody>
         </Table>
       </TableContainer>
-    </Layout>
+    </>
   );
 };
 

--- a/packages/ui/pages/index.tsx
+++ b/packages/ui/pages/index.tsx
@@ -97,7 +97,11 @@ const SuggestionOverview: React.FC<SuggestionOverviewProps> = (props) => {
   );
 };
 
-const Home: NextPage = () => {
+type NextPageWithLayout = NextPage & {
+  getLayout?: (page: React.ReactElement) => React.ReactNode;
+};
+
+const Home: NextPageWithLayout = () => {
   // TODO: talk to Lewis about making this a hook?
   const pluginProvider = new PluginProvider();
 
@@ -109,7 +113,6 @@ const Home: NextPage = () => {
 
   return (
     <Layout
-      title={data.report.root.name}
       hero={() => {
         return (
           <Paper variant="outlined" square={true}>
@@ -136,20 +139,26 @@ const Home: NextPage = () => {
           justifyContent="center"
         >
           {data &&
-            data.report.suggestions.map((suggestion) => {
+            data.report.suggestions.map((suggestion, idx) => {
               const CustomCardView = pluginProvider.cardView(
                 suggestion.pluginTarget
               );
               if (CustomCardView) {
-                return <CustomCardView suggestion={suggestion} />;
+                return (
+                  <CustomCardView suggestion={suggestion} key={suggestion.id} />
+                );
               } else {
-                return <CardView suggestion={suggestion} />;
+                return <CardView suggestion={suggestion} key={suggestion.id} />;
               }
             })}
         </Grid>
       </Container>
     </Layout>
   );
+};
+
+Home.getLayout = function getLayout(page: React.ReactElement) {
+  return <>{page}</>;
 };
 
 export default Home;

--- a/packages/ui/pages/index.tsx
+++ b/packages/ui/pages/index.tsx
@@ -7,12 +7,12 @@ import {
   Paper,
   Typography,
 } from '@mui/material';
-import type { NextPage } from 'next';
 import NextLink from 'next/link';
 
 import { CardView, Layout, LoadingView } from '../components';
 import { NexusGenFieldTypes } from '../graphql/generated/nexus-typegen';
 import { PluginProvider } from '../lib/PluginProvider';
+import { NextPageWithLayout } from '../next-types';
 
 export type Report = Pick<NexusGenFieldTypes['Report'], 'summary'> & {
   root: NexusGenFieldTypes['Package'];
@@ -95,10 +95,6 @@ const SuggestionOverview: React.FC<SuggestionOverviewProps> = (props) => {
       </Grid>
     </Container>
   );
-};
-
-type NextPageWithLayout = NextPage & {
-  getLayout?: (page: React.ReactElement) => React.ReactNode;
 };
 
 const Home: NextPageWithLayout = () => {

--- a/packages/ui/pages/packages/[name].tsx
+++ b/packages/ui/pages/packages/[name].tsx
@@ -3,7 +3,7 @@ import { NextPage } from 'next';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
-import { Layout, LoadingView } from '../../components';
+import { LoadingView } from '../../components';
 import { NexusGenFieldTypes } from '../../graphql/generated/nexus-typegen';
 
 interface PackageData {
@@ -76,7 +76,7 @@ const Package: NextPage = () => {
   if (!reportData) return <p>Oh no... could not load Report</p>;
 
   return (
-    <Layout title={reportData.report.root.name}>
+    <>
       <h1>Package: {name}</h1>
       {/* Why aren't the types  */}
       <h3>Versions:</h3>
@@ -118,7 +118,7 @@ const Package: NextPage = () => {
           </div>
         );
       })}
-    </Layout>
+    </>
   );
 };
 

--- a/packages/ui/pages/packages/[name]/[version].tsx
+++ b/packages/ui/pages/packages/[name]/[version].tsx
@@ -2,7 +2,7 @@ import { gql, useQuery } from '@apollo/client';
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 
-import { Layout, LoadingView } from '../../../components';
+import { LoadingView } from '../../../components';
 import { NexusGenFieldTypes } from '../../../graphql/generated/nexus-typegen';
 
 interface PackageData {
@@ -92,10 +92,10 @@ const Package: NextPage = () => {
   if (!reportData) return <p>Oh no... could not load Report</p>;
 
   return (
-    <Layout title={reportData.report.root.name}>
+    <>
       <h1>Package: {name}</h1>
       <pre>{JSON.stringify((data as any).packageByVersion, null, 4)}</pre>
-    </Layout>
+    </>
   );
 };
 

--- a/packages/ui/pages/packages/index.tsx
+++ b/packages/ui/pages/packages/index.tsx
@@ -12,7 +12,7 @@ import {
 import type { NextPage } from 'next';
 import NextLink from 'next/link';
 
-import { Layout, LoadingView } from '../../components';
+import { LoadingView } from '../../components';
 import { NexusGenFieldTypes } from '../../graphql/generated/nexus-typegen';
 
 type ColumnKey = 'name' | 'version' | 'dep-count' | 'dev-dep-count';
@@ -45,6 +45,7 @@ interface PackageData {
 const PackagesQuery = gql`
   query Packages {
     packages {
+      id
       name
       version
       dependencies {
@@ -87,47 +88,44 @@ const Packages: NextPage = () => {
   ];
 
   return (
-    <Layout title={reportData.report.root.name}>
-      <TableContainer component={Paper}>
-        <Table sx={{ minWidth: 650 }}>
-          <TableHead>
-            <TableRow>
-              {columns.map((column) => (
-                <TableCell key={column.key}>{column.label}</TableCell>
-              ))}
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {data.packages.map((dependency) => {
-              if (!dependency) return;
+    <TableContainer component={Paper}>
+      <Table sx={{ minWidth: 650 }}>
+        <TableHead>
+          <TableRow>
+            {columns.map((column) => (
+              <TableCell key={column.key}>{column.label}</TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {data.packages.map((dependency) => {
+            if (!dependency) return;
 
-              return (
-                <TableRow
-                  key={dependency.name}
-                  sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
-                >
-                  <TableCell component="th" scope="row">
-                    <NextLink
-                      href={`packages/${encodeURIComponent(dependency.name)}`}
-                      passHref={true}
-                    >
-                      <Link>{dependency.name}</Link>
-                    </NextLink>
-                  </TableCell>
-                  <TableCell component="th" scope="row">
-                    {dependency.version}
-                  </TableCell>
-                  <TableCell component="th" scope="row">
-                    {/* FIXME: need to figure out why the types are not passing through */}
-                    {(dependency as any).dependencies?.length}
-                  </TableCell>
-                </TableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
-      </TableContainer>
-    </Layout>
+            return (
+              <TableRow
+                key={dependency.id}
+                sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+              >
+                <TableCell component="th" scope="row">
+                  <NextLink
+                    href={`packages/${encodeURIComponent(dependency.name)}`}
+                    passHref={true}
+                  >
+                    <Link>{dependency.name}</Link>
+                  </NextLink>
+                </TableCell>
+                <TableCell component="th" scope="row">
+                  {dependency.version}
+                </TableCell>
+                <TableCell component="th" scope="row">
+                  {dependency.dependencies.length}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
   );
 };
 

--- a/packages/ui/pages/plugin/[name].tsx
+++ b/packages/ui/pages/plugin/[name].tsx
@@ -47,12 +47,7 @@ const Package: NextPage = () => {
   const PluginPageView = pluginProvider.pluginPageView(name);
 
   if (!PluginPageView) {
-    return (
-      <ErrorView
-        title="Plugin Page Error"
-        message="Plugin does not have a page view"
-      />
-    );
+    return <ErrorView message="Plugin does not have a page view" />;
   }
 
   // FIXME: Talk to Lewis about how to get data into the plugin page view

--- a/packages/ui/pages/plugin/[name].tsx
+++ b/packages/ui/pages/plugin/[name].tsx
@@ -2,7 +2,7 @@ import { gql, useQuery } from '@apollo/client';
 import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 
-import { ErrorView, Layout, LoadingView } from '../../components';
+import { ErrorView, LoadingView } from '../../components';
 import { NexusGenFieldTypes } from '../../graphql/generated/nexus-typegen';
 import { PluginProvider } from '../../lib/PluginProvider';
 
@@ -58,10 +58,10 @@ const Package: NextPage = () => {
   // FIXME: Talk to Lewis about how to get data into the plugin page view
   // it should be able make a graphql call
   return (
-    <Layout title={reportData.report.root.name}>
+    <>
       <h1>Plugin</h1>
       <PluginPageView />
-    </Layout>
+    </>
   );
 };
 

--- a/packages/ui/pages/suggestions/[id].tsx
+++ b/packages/ui/pages/suggestions/[id].tsx
@@ -13,7 +13,7 @@ import type { NextPage } from 'next';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 
-import { Layout, LoadingView } from '../../components';
+import { LoadingView } from '../../components';
 import { NexusGenFieldTypes } from '../../graphql/generated/nexus-typegen';
 interface ReportData {
   report: Pick<NexusGenFieldTypes['Report'], 'summary'> & {
@@ -82,57 +82,55 @@ const Suggestion: NextPage = () => {
   if (!reportData) return <p>Oh no... could not load Report</p>;
 
   return (
-    <Layout title={reportData.report.root.name}>
-      <Container sx={{ py: 8 }} maxWidth="md">
-        {data.suggestion.message}
-        <br />
-        <br />
-        <h2>Actions</h2>
-        <TableContainer component={Paper}>
-          <Table sx={{ minWidth: 650 }} aria-label="actions table">
-            <TableHead>
-              <TableRow>
-                <TableCell>Message</TableCell>
-                <TableCell align="right">Package</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {data.suggestion.actions
-                .filter((a) => a !== null)
-                .map((_action, idx) => {
-                  // FIXME: we shouldn't have to do this.
-                  const action =
-                    _action as NexusGenFieldTypes['SuggestionAction'];
+    <Container sx={{ py: 8 }} maxWidth="md">
+      {data.suggestion.message}
+      <br />
+      <br />
+      <h2>Actions</h2>
+      <TableContainer component={Paper}>
+        <Table sx={{ minWidth: 650 }} aria-label="actions table">
+          <TableHead>
+            <TableRow>
+              <TableCell>Message</TableCell>
+              <TableCell align="right">Package</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {data.suggestion.actions
+              .filter((a) => a !== null)
+              .map((_action, idx) => {
+                // FIXME: we shouldn't have to do this.
+                const action =
+                  _action as NexusGenFieldTypes['SuggestionAction'];
 
-                  return (
-                    <TableRow
-                      key={idx}
-                      sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
-                    >
-                      <TableCell component="th" scope="row">
-                        {action?.message}
-                      </TableCell>
-                      <TableCell align="right">
-                        {action?.targetPackage?.name ? (
-                          <Link
-                            href={`/packages/${encodeURIComponent(
-                              action.targetPackage.name
-                            )}`}
-                          >
-                            {action.targetPackage.name}
-                          </Link>
-                        ) : (
-                          'None'
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  );
-                })}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      </Container>
-    </Layout>
+                return (
+                  <TableRow
+                    key={idx}
+                    sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
+                  >
+                    <TableCell component="th" scope="row">
+                      {action?.message}
+                    </TableCell>
+                    <TableCell align="right">
+                      {action?.targetPackage?.name ? (
+                        <Link
+                          href={`/packages/${encodeURIComponent(
+                            action.targetPackage.name
+                          )}`}
+                        >
+                          {action.targetPackage.name}
+                        </Link>
+                      ) : (
+                        'None'
+                      )}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Container>
   );
 };
 


### PR DESCRIPTION
## Summary

Switch to using a root `Layout` component instead of forcing every page to wrap their page with it.

## Details

- refactor: the NavBar to fetch the title of the application via GraphQL.
- refactor: the base app file to determine if a page provides its own Layout or to use the default.
- fix: multiple react bugs that were erroring out in console.

Resolves: #50