### PR TITLE
feat: adds data-grid to suggestions page

### DIFF
--- a/packages/ui/pages/suggestions/[id].tsx
+++ b/packages/ui/pages/suggestions/[id].tsx
@@ -1,16 +1,8 @@
 import { gql } from '@apollo/client';
-import {
-  Container,
-  Paper,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-} from '@mui/material';
+import { Container, Link } from '@mui/material';
+import { DataGrid, GridToolbar } from '@mui/x-data-grid';
 import type { NextPage } from 'next';
-import Link from 'next/link';
+import NextLink from 'next/link';
 import { useRouter } from 'next/router';
 
 import { LoadingView } from '../../components';
@@ -57,45 +49,40 @@ const Suggestion: NextPage = () => {
       <br />
       <br />
       <h2>Actions</h2>
-      <TableContainer component={Paper}>
-        <Table sx={{ minWidth: 650 }} aria-label="actions table">
-          <TableHead>
-            <TableRow>
-              <TableCell>Message</TableCell>
-              <TableCell align="right">Package</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {data?.suggestion?.actions
-              ?.filter((a) => a !== null)
-              .map((action, idx) => {
-                return (
-                  <TableRow
-                    key={idx}
-                    sx={{ '&:last-child td, &:last-child th': { border: 0 } }}
-                  >
-                    <TableCell component="th" scope="row">
-                      {action?.message}
-                    </TableCell>
-                    <TableCell align="right">
-                      {action?.targetPackage?.name ? (
-                        <Link
-                          href={`/packages/${encodeURIComponent(
-                            action.targetPackage.name
-                          )}`}
-                        >
-                          {action.targetPackage.name}
-                        </Link>
-                      ) : (
-                        'None'
-                      )}
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
-          </TableBody>
-        </Table>
-      </TableContainer>
+      <div style={{ height: 500, width: '100%' }}>
+        <div style={{ display: 'flex', height: '100%' }}>
+          <div style={{ flexGrow: 1 }}>
+            <DataGrid
+              columns={[
+                { field: 'message', flex: 1 },
+                {
+                  field: 'packageName',
+                  renderCell(params) {
+                    return (
+                      <NextLink
+                        href={`packages/${encodeURIComponent(params.value)}`}
+                        passHref={true}
+                      >
+                        <Link>{params.value}</Link>
+                      </NextLink>
+                    );
+                  },
+                },
+              ]}
+              rows={
+                data?.suggestion?.actions.map((action, i) => {
+                  return {
+                    id: i,
+                    message: action?.message || 'N/A',
+                    packageName: action?.targetPackage?.name || 'N/A',
+                  };
+                }) || []
+              }
+              components={{ Toolbar: GridToolbar }}
+            />
+          </div>
+        </div>
+      </div>
     </Container>
   );
 };

--- a/packages/ui/styles/globals.css
+++ b/packages/ui/styles/globals.css
@@ -22,3 +22,21 @@ a {
   display: flex;
   flex-direction: column;
 }
+
+/* TODO: get rid of this when https://github.com/mui/mui-x/pull/4859 lands */
+.MuiDataGrid-viewport,
+.MuiDataGrid-row,
+.MuiDataGrid-renderingZone {
+  max-height: none !important;
+}
+
+.MuiDataGrid-cell {
+  max-height: none !important;
+  overflow: auto;
+  white-space: initial !important;
+  line-height: 16px !important;
+  display: flex !important;
+  align-items: center;
+  padding-top: 10px !important;
+  padding-bottom: 10px !important;
+}


### PR DESCRIPTION
* [feat: adds data-grid to suggestions page](https://github.com/es-maintenance/package-inspector/pull/66/commits/5c03f9c454930a62ecf7db881b51396649204f75)

## Before
<img width="1505" alt="Screen Shot 2022-05-13 at 4 05 47 PM" src="https://user-images.githubusercontent.com/1854811/168400029-c3add226-f895-48ad-a0a7-001d7e399ae1.png">
## After
<img width="1505" alt="Screen Shot 2022-05-13 at 4 08 24 PM" src="https://user-images.githubusercontent.com/1854811/168400032-b7608064-267b-4e0e-8cef-616395d7a6a8.png">



