### PR TITLE
feat: Use relay cursor spec for lists of data

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "graphql-config.load.rootDir": "packages/ui/"
+}

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -14,7 +14,8 @@
     "test:ci": "echo 'TESTING NOT AVAILABLE YET'"
   },
   "dependencies": {
-    "@package-inspector/core": "*"
+    "@package-inspector/core": "*",
+    "graphql-relay": "^0.10.0"
   },
   "devDependencies": {
     "nexus": "^1.3.0",

--- a/packages/graphql/src/codegen/nexus-typegen.ts
+++ b/packages/graphql/src/codegen/nexus-typegen.ts
@@ -4,6 +4,30 @@
  */
 
 import type { Context } from './../context';
+import type { core, connectionPluginCore } from 'nexus';
+
+declare global {
+  interface NexusGenCustomOutputMethods<TypeName extends string> {
+    /**
+     * Adds a Relay-style connection to the type, with numerous options for configuration
+     *
+     * @see https://nexusjs.org/docs/plugins/connection
+     */
+    connectionField<FieldName extends string>(
+      fieldName: FieldName,
+      config: connectionPluginCore.ConnectionFieldConfig<
+        TypeName,
+        FieldName
+      > & {
+        totalCount: connectionPluginCore.ConnectionFieldResolver<
+          TypeName,
+          FieldName,
+          'totalCount'
+        >;
+      }
+    ): void;
+  }
+}
 
 declare global {
   interface NexusGen extends NexusGenTypes {}
@@ -27,6 +51,18 @@ export interface NexusGenObjects {
     name: string; // String!
     version: string; // String!
   };
+  MiniPackageConnection: {
+    // root type
+    edges?: Array<NexusGenRootTypes['MiniPackageEdge'] | null> | null; // [MiniPackageEdge]
+    nodes?: Array<NexusGenRootTypes['MiniPackage'] | null> | null; // [MiniPackage]
+    pageInfo: NexusGenRootTypes['PageInfo']; // PageInfo!
+    totalCount?: number | null; // Int
+  };
+  MiniPackageEdge: {
+    // root type
+    cursor: string; // String!
+    node?: NexusGenRootTypes['MiniPackage'] | null; // MiniPackage
+  };
   Package: {
     // root type
     funding?: string | null; // String
@@ -40,17 +76,35 @@ export interface NexusGenObjects {
     // root type
     name: string; // String!
   };
+  PackageConnection: {
+    // root type
+    edges?: Array<NexusGenRootTypes['PackageEdge'] | null> | null; // [PackageEdge]
+    nodes?: Array<NexusGenRootTypes['Package'] | null> | null; // [Package]
+    pageInfo: NexusGenRootTypes['PageInfo']; // PageInfo!
+    totalCount?: number | null; // Int
+  };
+  PackageEdge: {
+    // root type
+    cursor: string; // String!
+    node?: NexusGenRootTypes['Package'] | null; // Package
+  };
   PackageMetadata: {
     // root type
     pathsOnDisk?: Array<string | null> | null; // [String]
     size?: NexusGenRootTypes['SizeInfo'] | null; // SizeInfo
+  };
+  PageInfo: {
+    // root type
+    endCursor?: string | null; // String
+    hasNextPage: boolean; // Boolean!
+    hasPreviousPage: boolean; // Boolean!
+    startCursor?: string | null; // String
   };
   Query: {};
   Report: {
     // root type
     id: string; // ID!
     root: NexusGenRootTypes['Package']; // Package!
-    suggestions: Array<NexusGenRootTypes['Suggestion'] | null>; // [Suggestion]!
   };
   SizeInfo: {
     // root type
@@ -70,10 +124,34 @@ export interface NexusGenObjects {
     message: string; // String!
     targetPackageId: string; // String!
   };
+  SuggestionConnection: {
+    // root type
+    edges?: Array<NexusGenRootTypes['SuggestionEdge'] | null> | null; // [SuggestionEdge]
+    nodes?: Array<NexusGenRootTypes['Suggestion'] | null> | null; // [Suggestion]
+    pageInfo: NexusGenRootTypes['PageInfo']; // PageInfo!
+    totalCount?: number | null; // Int
+  };
+  SuggestionEdge: {
+    // root type
+    cursor: string; // String!
+    node?: NexusGenRootTypes['Suggestion'] | null; // Suggestion
+  };
   TopSuggestions: {
     // root type
     count: number; // Int!
     package: NexusGenRootTypes['Package']; // Package!
+  };
+  TopSuggestionsConnection: {
+    // root type
+    edges?: Array<NexusGenRootTypes['TopSuggestionsEdge'] | null> | null; // [TopSuggestionsEdge]
+    nodes?: Array<NexusGenRootTypes['TopSuggestions'] | null> | null; // [TopSuggestions]
+    pageInfo: NexusGenRootTypes['PageInfo']; // PageInfo!
+    totalCount?: number | null; // Int
+  };
+  TopSuggestionsEdge: {
+    // root type
+    cursor: string; // String!
+    node?: NexusGenRootTypes['TopSuggestions'] | null; // TopSuggestions
   };
 }
 
@@ -91,17 +169,29 @@ export interface NexusGenFieldTypes {
     name: string; // String!
     version: string; // String!
   };
+  MiniPackageConnection: {
+    // field return type
+    edges: Array<NexusGenRootTypes['MiniPackageEdge'] | null> | null; // [MiniPackageEdge]
+    nodes: Array<NexusGenRootTypes['MiniPackage'] | null> | null; // [MiniPackage]
+    pageInfo: NexusGenRootTypes['PageInfo']; // PageInfo!
+    totalCount: number | null; // Int
+  };
+  MiniPackageEdge: {
+    // field return type
+    cursor: string; // String!
+    node: NexusGenRootTypes['MiniPackage'] | null; // MiniPackage
+  };
   Package: {
     // field return type
-    dependencies: Array<NexusGenRootTypes['Package'] | null>; // [Package]!
+    dependencies: NexusGenRootTypes['PackageConnection']; // PackageConnection!
     dependencyCount: number; // Int!
     funding: string | null; // String
     homepage: string | null; // String
     id: string; // ID!
     metadata: NexusGenRootTypes['PackageMetadata'] | null; // PackageMetadata
     name: string; // String!
-    parent: Array<NexusGenRootTypes['Package'] | null>; // [Package]!
-    suggestions: Array<NexusGenRootTypes['Suggestion'] | null>; // [Suggestion]!
+    parent: NexusGenRootTypes['PackageConnection']; // PackageConnection!
+    suggestions: NexusGenRootTypes['SuggestionConnection']; // SuggestionConnection!
     type: string | null; // String
     version: string; // String!
   };
@@ -109,31 +199,50 @@ export interface NexusGenFieldTypes {
     // field return type
     latest: string; // String!
     name: string; // String!
-    variants: Array<NexusGenRootTypes['Package'] | null>; // [Package]!
+    variants: NexusGenRootTypes['PackageConnection']; // PackageConnection!
+  };
+  PackageConnection: {
+    // field return type
+    edges: Array<NexusGenRootTypes['PackageEdge'] | null> | null; // [PackageEdge]
+    nodes: Array<NexusGenRootTypes['Package'] | null> | null; // [Package]
+    pageInfo: NexusGenRootTypes['PageInfo']; // PageInfo!
+    totalCount: number | null; // Int
+  };
+  PackageEdge: {
+    // field return type
+    cursor: string; // String!
+    node: NexusGenRootTypes['Package'] | null; // Package
   };
   PackageMetadata: {
     // field return type
     pathsOnDisk: Array<string | null> | null; // [String]
     size: NexusGenRootTypes['SizeInfo'] | null; // SizeInfo
   };
+  PageInfo: {
+    // field return type
+    endCursor: string | null; // String
+    hasNextPage: boolean; // Boolean!
+    hasPreviousPage: boolean; // Boolean!
+    startCursor: string | null; // String
+  };
   Query: {
     // field return type
     package: NexusGenRootTypes['PackageCompound'] | null; // PackageCompound
     packageByVersion: NexusGenRootTypes['Package'] | null; // Package
-    packages: Array<NexusGenRootTypes['Package'] | null>; // [Package]!
+    packages: NexusGenRootTypes['PackageConnection']; // PackageConnection!
     report: NexusGenRootTypes['Report']; // Report!
     suggestion: NexusGenRootTypes['Suggestion'] | null; // Suggestion
     title: string; // String!
   };
   Report: {
     // field return type
-    dependencies: Array<NexusGenRootTypes['Package'] | null>; // [Package]!
+    dependencies: NexusGenRootTypes['PackageConnection']; // PackageConnection!
     id: string; // ID!
-    latestPackages: Array<NexusGenRootTypes['MiniPackage'] | null>; // [MiniPackage]!
+    latestPackages: NexusGenRootTypes['MiniPackageConnection']; // MiniPackageConnection!
     root: NexusGenRootTypes['Package']; // Package!
-    suggestions: Array<NexusGenRootTypes['Suggestion'] | null>; // [Suggestion]!
+    suggestions: NexusGenRootTypes['SuggestionConnection']; // SuggestionConnection!
     summary: string; // String!
-    topSuggestions: Array<NexusGenRootTypes['TopSuggestions'] | null>; // [TopSuggestions]!
+    topSuggestions: NexusGenRootTypes['TopSuggestionsConnection']; // TopSuggestionsConnection!
   };
   SizeInfo: {
     // field return type
@@ -155,10 +264,34 @@ export interface NexusGenFieldTypes {
     targetPackage: NexusGenRootTypes['Package'] | null; // Package
     targetPackageId: string; // String!
   };
+  SuggestionConnection: {
+    // field return type
+    edges: Array<NexusGenRootTypes['SuggestionEdge'] | null> | null; // [SuggestionEdge]
+    nodes: Array<NexusGenRootTypes['Suggestion'] | null> | null; // [Suggestion]
+    pageInfo: NexusGenRootTypes['PageInfo']; // PageInfo!
+    totalCount: number | null; // Int
+  };
+  SuggestionEdge: {
+    // field return type
+    cursor: string; // String!
+    node: NexusGenRootTypes['Suggestion'] | null; // Suggestion
+  };
   TopSuggestions: {
     // field return type
     count: number; // Int!
     package: NexusGenRootTypes['Package']; // Package!
+  };
+  TopSuggestionsConnection: {
+    // field return type
+    edges: Array<NexusGenRootTypes['TopSuggestionsEdge'] | null> | null; // [TopSuggestionsEdge]
+    nodes: Array<NexusGenRootTypes['TopSuggestions'] | null> | null; // [TopSuggestions]
+    pageInfo: NexusGenRootTypes['PageInfo']; // PageInfo!
+    totalCount: number | null; // Int
+  };
+  TopSuggestionsEdge: {
+    // field return type
+    cursor: string; // String!
+    node: NexusGenRootTypes['TopSuggestions'] | null; // TopSuggestions
   };
 }
 
@@ -168,17 +301,29 @@ export interface NexusGenFieldTypeNames {
     name: 'String';
     version: 'String';
   };
+  MiniPackageConnection: {
+    // field return type name
+    edges: 'MiniPackageEdge';
+    nodes: 'MiniPackage';
+    pageInfo: 'PageInfo';
+    totalCount: 'Int';
+  };
+  MiniPackageEdge: {
+    // field return type name
+    cursor: 'String';
+    node: 'MiniPackage';
+  };
   Package: {
     // field return type name
-    dependencies: 'Package';
+    dependencies: 'PackageConnection';
     dependencyCount: 'Int';
     funding: 'String';
     homepage: 'String';
     id: 'ID';
     metadata: 'PackageMetadata';
     name: 'String';
-    parent: 'Package';
-    suggestions: 'Suggestion';
+    parent: 'PackageConnection';
+    suggestions: 'SuggestionConnection';
     type: 'String';
     version: 'String';
   };
@@ -186,31 +331,50 @@ export interface NexusGenFieldTypeNames {
     // field return type name
     latest: 'String';
     name: 'String';
-    variants: 'Package';
+    variants: 'PackageConnection';
+  };
+  PackageConnection: {
+    // field return type name
+    edges: 'PackageEdge';
+    nodes: 'Package';
+    pageInfo: 'PageInfo';
+    totalCount: 'Int';
+  };
+  PackageEdge: {
+    // field return type name
+    cursor: 'String';
+    node: 'Package';
   };
   PackageMetadata: {
     // field return type name
     pathsOnDisk: 'String';
     size: 'SizeInfo';
   };
+  PageInfo: {
+    // field return type name
+    endCursor: 'String';
+    hasNextPage: 'Boolean';
+    hasPreviousPage: 'Boolean';
+    startCursor: 'String';
+  };
   Query: {
     // field return type name
     package: 'PackageCompound';
     packageByVersion: 'Package';
-    packages: 'Package';
+    packages: 'PackageConnection';
     report: 'Report';
     suggestion: 'Suggestion';
     title: 'String';
   };
   Report: {
     // field return type name
-    dependencies: 'Package';
+    dependencies: 'PackageConnection';
     id: 'ID';
-    latestPackages: 'MiniPackage';
+    latestPackages: 'MiniPackageConnection';
     root: 'Package';
-    suggestions: 'Suggestion';
+    suggestions: 'SuggestionConnection';
     summary: 'String';
-    topSuggestions: 'TopSuggestions';
+    topSuggestions: 'TopSuggestionsConnection';
   };
   SizeInfo: {
     // field return type name
@@ -232,14 +396,70 @@ export interface NexusGenFieldTypeNames {
     targetPackage: 'Package';
     targetPackageId: 'String';
   };
+  SuggestionConnection: {
+    // field return type name
+    edges: 'SuggestionEdge';
+    nodes: 'Suggestion';
+    pageInfo: 'PageInfo';
+    totalCount: 'Int';
+  };
+  SuggestionEdge: {
+    // field return type name
+    cursor: 'String';
+    node: 'Suggestion';
+  };
   TopSuggestions: {
     // field return type name
     count: 'Int';
     package: 'Package';
   };
+  TopSuggestionsConnection: {
+    // field return type name
+    edges: 'TopSuggestionsEdge';
+    nodes: 'TopSuggestions';
+    pageInfo: 'PageInfo';
+    totalCount: 'Int';
+  };
+  TopSuggestionsEdge: {
+    // field return type name
+    cursor: 'String';
+    node: 'TopSuggestions';
+  };
 }
 
 export interface NexusGenArgTypes {
+  Package: {
+    dependencies: {
+      // args
+      after?: string | null; // String
+      before?: string | null; // String
+      first?: number | null; // Int
+      last?: number | null; // Int
+    };
+    parent: {
+      // args
+      after?: string | null; // String
+      before?: string | null; // String
+      first?: number | null; // Int
+      last?: number | null; // Int
+    };
+    suggestions: {
+      // args
+      after?: string | null; // String
+      before?: string | null; // String
+      first?: number | null; // Int
+      last?: number | null; // Int
+    };
+  };
+  PackageCompound: {
+    variants: {
+      // args
+      after?: string | null; // String
+      before?: string | null; // String
+      first?: number | null; // Int
+      last?: number | null; // Int
+    };
+  };
   Query: {
     package: {
       // args
@@ -250,9 +470,46 @@ export interface NexusGenArgTypes {
       packageName: string; // String!
       packageVersion: string; // String!
     };
+    packages: {
+      // args
+      after?: string | null; // String
+      before?: string | null; // String
+      first?: number | null; // Int
+      last?: number | null; // Int
+    };
     suggestion: {
       // args
       id: string; // String!
+    };
+  };
+  Report: {
+    dependencies: {
+      // args
+      after?: string | null; // String
+      before?: string | null; // String
+      first?: number | null; // Int
+      last?: number | null; // Int
+    };
+    latestPackages: {
+      // args
+      after?: string | null; // String
+      before?: string | null; // String
+      first?: number | null; // Int
+      last?: number | null; // Int
+    };
+    suggestions: {
+      // args
+      after?: string | null; // String
+      before?: string | null; // String
+      first?: number | null; // Int
+      last?: number | null; // Int
+    };
+    topSuggestions: {
+      // args
+      after?: string | null; // String
+      before?: string | null; // String
+      first?: number | null; // Int
+      last?: number | null; // Int
     };
   };
 }

--- a/packages/graphql/src/schema.ts
+++ b/packages/graphql/src/schema.ts
@@ -1,4 +1,4 @@
-import { makeSchema } from 'nexus';
+import { makeSchema, connectionPlugin } from 'nexus';
 import { join } from 'path';
 
 import * as types from './types';
@@ -13,4 +13,12 @@ export const schema = makeSchema({
     module: join(__dirname, 'context.ts'),
     export: 'Context',
   },
+  plugins: [
+    connectionPlugin({
+      includeNodesField: true,
+      extendConnection: {
+        totalCount: { type: 'Int' },
+      },
+    }),
+  ],
 });

--- a/packages/graphql/src/types/Package.ts
+++ b/packages/graphql/src/types/Package.ts
@@ -1,7 +1,7 @@
 import { parseDependencyKey } from '@package-inspector/core';
+import { connectionFromArray } from 'graphql-relay';
 import { extendType, nonNull, objectType, stringArg } from 'nexus';
 
-import { Context } from '../context';
 import { getPackageID } from '../utils';
 import { Suggestion } from './Suggestion';
 
@@ -43,9 +43,9 @@ export const PackageCompound = objectType({
         return ctx.report.latestPackages[name];
       },
     });
-    t.nonNull.list.field('variants', {
+    t.nonNull.connectionField('variants', {
       type: Package,
-      resolve(me, __, ctx) {
+      resolve(me, args, ctx) {
         const packageName = me.name;
 
         const variants = Object.keys(ctx.report.dependencies).filter(
@@ -54,7 +54,7 @@ export const PackageCompound = objectType({
           }
         );
 
-        return variants
+        const entries = variants
           ? variants.map((depID: string) => {
               const pkgDep = ctx.report.dependencies[depID];
               return {
@@ -65,6 +65,14 @@ export const PackageCompound = objectType({
               };
             })
           : [];
+
+        return {
+          ...connectionFromArray(entries, args),
+          totalCount: entries.length,
+        };
+      },
+      totalCount: (me, args, ctx) => {
+        return 0;
       },
     });
   },
@@ -87,15 +95,14 @@ export const Package = objectType({
       },
     });
 
-    t.nonNull.list.field('dependencies', {
+    t.nonNull.connectionField('dependencies', {
       type: Package,
-      resolve(me, __, ctx) {
+      resolve(me, args, ctx) {
         const pkg =
           me.name === ctx.report.root.name
             ? ctx.report.root // If this is the root, get the serialized-package from the report's root.
             : ctx.report.dependencies[me.id]; // Otherwise find the package definition in the provided map.
-
-        return pkg
+        const entries = pkg
           ? pkg.dependencies.map((depID) => {
               const pkgDep = ctx.report.dependencies[depID];
               return {
@@ -106,17 +113,24 @@ export const Package = objectType({
               };
             })
           : [];
+
+        return {
+          ...connectionFromArray(entries, args),
+          totalCount: entries.length,
+        };
+      },
+      totalCount: (me, args, ctx) => {
+        return 0;
       },
     });
 
     // This is the list of parents that bring in this dependency
-    t.nonNull.list.field('parent', {
+    t.nonNull.connectionField('parent', {
       type: Package,
-      resolve(me, __, ctx) {
+      resolve(me, args, ctx) {
         // This is going to give us the packageKey
         const id = me.id;
-
-        return Object.keys(ctx.report.dependencies)
+        const entries = Object.keys(ctx.report.dependencies)
           .filter((depId) => {
             return ctx.report.dependencies[depId].dependencies.indexOf(id) > -1;
           })
@@ -126,16 +140,23 @@ export const Package = objectType({
               ...ctx.report.dependencies[depId],
             };
           });
+
+        return {
+          ...connectionFromArray(entries, args),
+          totalCount: entries.length,
+        };
+      },
+      totalCount: (root, args, ctx) => {
+        return 0;
       },
     });
 
-    t.nonNull.list.field('suggestions', {
+    t.nonNull.connectionField('suggestions', {
       type: Suggestion,
-      resolve(me, __, ctx) {
+      resolve(me, args, ctx) {
         // This is going to give us the packageKey
         const id = me.id;
-
-        return ctx.report.suggestions
+        const entries = ctx.report.suggestions
           .map((suggestion) => {
             return {
               ...suggestion,
@@ -148,6 +169,14 @@ export const Package = objectType({
             // only return suggestions that have suggestions that have actions
             return suggestion?.actions.length > 0;
           });
+
+        return {
+          ...connectionFromArray(entries, args),
+          totalCount: entries.length,
+        };
+      },
+      totalCount: (root, args, ctx) => {
+        return 0;
       },
     });
 
@@ -178,16 +207,24 @@ export const Package = objectType({
 export const PackagesQuery = extendType({
   type: 'Query',
   definition(t) {
-    t.nonNull.list.field('packages', {
+    t.nonNull.connectionField('packages', {
       type: Package,
-      resolve(_, __, ctx) {
-        return Object.values(ctx.report.dependencies).map((dep) => {
+      resolve(_, args, ctx) {
+        const entries = Object.values(ctx.report.dependencies).map((dep) => {
           return {
             id: getPackageID(dep),
             name: dep.name,
             version: dep.version,
           };
         });
+
+        return {
+          ...connectionFromArray(entries, args),
+          totalCount: entries.length,
+        };
+      },
+      totalCount: (root, args, ctx) => {
+        return 0;
       },
     });
   },

--- a/packages/ui/.graphqlrc.js
+++ b/packages/ui/.graphqlrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  schema: require.resolve(
+    `@package-inspector/graphql/dist/codegen/schema.graphql`
+  ),
+};

--- a/packages/ui/graphql/generated/client.ts
+++ b/packages/ui/graphql/generated/client.ts
@@ -27,26 +27,92 @@ export type MiniPackage = {
   version: Scalars['String'];
 };
 
+export type MiniPackageConnection = {
+  __typename?: 'MiniPackageConnection';
+  /** https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types */
+  edges?: Maybe<Array<Maybe<MiniPackageEdge>>>;
+  /** Flattened list of MiniPackage type */
+  nodes?: Maybe<Array<Maybe<MiniPackage>>>;
+  /** https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo */
+  pageInfo: PageInfo;
+  totalCount?: Maybe<Scalars['Int']>;
+};
+
+export type MiniPackageEdge = {
+  __typename?: 'MiniPackageEdge';
+  /** https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor */
+  cursor: Scalars['String'];
+  /** https://facebook.github.io/relay/graphql/connections.htm#sec-Node */
+  node?: Maybe<MiniPackage>;
+};
+
 export type Package = {
   __typename?: 'Package';
-  dependencies: Array<Maybe<Package>>;
+  dependencies: PackageConnection;
   dependencyCount: Scalars['Int'];
   funding?: Maybe<Scalars['String']>;
   homepage?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
   metadata?: Maybe<PackageMetadata>;
   name: Scalars['String'];
-  parent: Array<Maybe<Package>>;
-  suggestions: Array<Maybe<Suggestion>>;
+  parent: PackageConnection;
+  suggestions: SuggestionConnection;
   type?: Maybe<Scalars['String']>;
   version: Scalars['String'];
+};
+
+export type PackagedependenciesArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
+export type PackageparentArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
+export type PackagesuggestionsArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
 };
 
 export type PackageCompound = {
   __typename?: 'PackageCompound';
   latest: Scalars['String'];
   name: Scalars['String'];
-  variants: Array<Maybe<Package>>;
+  variants: PackageConnection;
+};
+
+export type PackageCompoundvariantsArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
+export type PackageConnection = {
+  __typename?: 'PackageConnection';
+  /** https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types */
+  edges?: Maybe<Array<Maybe<PackageEdge>>>;
+  /** Flattened list of Package type */
+  nodes?: Maybe<Array<Maybe<Package>>>;
+  /** https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo */
+  pageInfo: PageInfo;
+  totalCount?: Maybe<Scalars['Int']>;
+};
+
+export type PackageEdge = {
+  __typename?: 'PackageEdge';
+  /** https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor */
+  cursor: Scalars['String'];
+  /** https://facebook.github.io/relay/graphql/connections.htm#sec-Node */
+  node?: Maybe<Package>;
 };
 
 export type PackageMetadata = {
@@ -55,11 +121,24 @@ export type PackageMetadata = {
   size?: Maybe<SizeInfo>;
 };
 
+/** PageInfo cursor, as defined in https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo */
+export type PageInfo = {
+  __typename?: 'PageInfo';
+  /** The cursor corresponding to the last nodes in edges. Null if the connection is empty. */
+  endCursor?: Maybe<Scalars['String']>;
+  /** Used to indicate whether more edges exist following the set defined by the clients arguments. */
+  hasNextPage: Scalars['Boolean'];
+  /** Used to indicate whether more edges exist prior to the set defined by the clients arguments. */
+  hasPreviousPage: Scalars['Boolean'];
+  /** The cursor corresponding to the first nodes in edges. Null if the connection is empty. */
+  startCursor?: Maybe<Scalars['String']>;
+};
+
 export type Query = {
   __typename?: 'Query';
   package?: Maybe<PackageCompound>;
   packageByVersion?: Maybe<Package>;
-  packages: Array<Maybe<Package>>;
+  packages: PackageConnection;
   report: Report;
   suggestion?: Maybe<Suggestion>;
   title: Scalars['String'];
@@ -74,19 +153,54 @@ export type QuerypackageByVersionArgs = {
   packageVersion: Scalars['String'];
 };
 
+export type QuerypackagesArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
 export type QuerysuggestionArgs = {
   id: Scalars['String'];
 };
 
 export type Report = {
   __typename?: 'Report';
-  dependencies: Array<Maybe<Package>>;
+  dependencies: PackageConnection;
   id: Scalars['ID'];
-  latestPackages: Array<Maybe<MiniPackage>>;
+  latestPackages: MiniPackageConnection;
   root: Package;
-  suggestions: Array<Maybe<Suggestion>>;
+  suggestions: SuggestionConnection;
   summary: Scalars['String'];
-  topSuggestions: Array<Maybe<TopSuggestions>>;
+  topSuggestions: TopSuggestionsConnection;
+};
+
+export type ReportdependenciesArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
+export type ReportlatestPackagesArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
+export type ReportsuggestionsArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+};
+
+export type ReporttopSuggestionsArgs = {
+  after?: InputMaybe<Scalars['String']>;
+  before?: InputMaybe<Scalars['String']>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
 };
 
 export type SizeInfo = {
@@ -112,10 +226,48 @@ export type SuggestionAction = {
   targetPackageId: Scalars['String'];
 };
 
+export type SuggestionConnection = {
+  __typename?: 'SuggestionConnection';
+  /** https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types */
+  edges?: Maybe<Array<Maybe<SuggestionEdge>>>;
+  /** Flattened list of Suggestion type */
+  nodes?: Maybe<Array<Maybe<Suggestion>>>;
+  /** https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo */
+  pageInfo: PageInfo;
+  totalCount?: Maybe<Scalars['Int']>;
+};
+
+export type SuggestionEdge = {
+  __typename?: 'SuggestionEdge';
+  /** https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor */
+  cursor: Scalars['String'];
+  /** https://facebook.github.io/relay/graphql/connections.htm#sec-Node */
+  node?: Maybe<Suggestion>;
+};
+
 export type TopSuggestions = {
   __typename?: 'TopSuggestions';
   count: Scalars['Int'];
   package: Package;
+};
+
+export type TopSuggestionsConnection = {
+  __typename?: 'TopSuggestionsConnection';
+  /** https://facebook.github.io/relay/graphql/connections.htm#sec-Edge-Types */
+  edges?: Maybe<Array<Maybe<TopSuggestionsEdge>>>;
+  /** Flattened list of TopSuggestions type */
+  nodes?: Maybe<Array<Maybe<TopSuggestions>>>;
+  /** https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo */
+  pageInfo: PageInfo;
+  totalCount?: Maybe<Scalars['Int']>;
+};
+
+export type TopSuggestionsEdge = {
+  __typename?: 'TopSuggestionsEdge';
+  /** https://facebook.github.io/relay/graphql/connections.htm#sec-Cursor */
+  cursor: Scalars['String'];
+  /** https://facebook.github.io/relay/graphql/connections.htm#sec-Node */
+  node?: Maybe<TopSuggestions>;
 };
 
 export type NavbarTitleQueryVariables = Exact<{ [key: string]: never }>;
@@ -133,21 +285,24 @@ export type DetailsReportQuery = {
       __typename?: 'Package';
       name: string;
       version: string;
-      dependencies: Array<{
-        __typename?: 'Package';
-        id: string;
-        name: string;
-        version: string;
-        type?: string | null;
-        metadata?: {
-          __typename?: 'PackageMetadata';
-          size?: {
-            __typename?: 'SizeInfo';
-            files?: number | null;
-            physical?: number | null;
+      dependencies: {
+        __typename?: 'PackageConnection';
+        nodes?: Array<{
+          __typename?: 'Package';
+          id: string;
+          name: string;
+          version: string;
+          type?: string | null;
+          metadata?: {
+            __typename?: 'PackageMetadata';
+            size?: {
+              __typename?: 'SizeInfo';
+              files?: number | null;
+              physical?: number | null;
+            } | null;
           } | null;
-        } | null;
-      } | null>;
+        } | null> | null;
+      };
     };
   };
 };
@@ -179,30 +334,31 @@ export type IndexReportQuery = {
   report: {
     __typename?: 'Report';
     summary: string;
-    root: {
-      __typename?: 'Package';
-      name: string;
-      version: string;
-      dependencies: Array<{ __typename?: 'Package'; id: string } | null>;
+    root: { __typename?: 'Package'; name: string; version: string };
+    topSuggestions: {
+      __typename?: 'TopSuggestionsConnection';
+      nodes?: Array<{
+        __typename?: 'TopSuggestions';
+        count: number;
+        package: {
+          __typename?: 'Package';
+          id: string;
+          version: string;
+          name: string;
+        };
+      } | null> | null;
     };
-    topSuggestions: Array<{
-      __typename?: 'TopSuggestions';
-      count: number;
-      package: {
-        __typename?: 'Package';
+    suggestions: {
+      __typename?: 'SuggestionConnection';
+      nodes?: Array<{
+        __typename?: 'Suggestion';
         id: string;
-        version: string;
+        pluginTarget: string;
         name: string;
-      };
-    } | null>;
-    suggestions: Array<{
-      __typename?: 'Suggestion';
-      id: string;
-      pluginTarget: string;
-      name: string;
-      message: string;
-      count: number;
-    } | null>;
+        message: string;
+        count: number;
+      } | null> | null;
+    };
   };
 };
 
@@ -216,18 +372,24 @@ export type PackageByNamePackageInfoQuery = {
     __typename?: 'PackageCompound';
     name: string;
     latest: string;
-    variants: Array<{
-      __typename?: 'Package';
-      id: string;
-      version: string;
-      name: string;
-      parent: Array<{
+    variants: {
+      __typename?: 'PackageConnection';
+      nodes?: Array<{
         __typename?: 'Package';
         id: string;
-        name: string;
         version: string;
-      } | null>;
-    } | null>;
+        name: string;
+        parent: {
+          __typename?: 'PackageConnection';
+          nodes?: Array<{
+            __typename?: 'Package';
+            id: string;
+            name: string;
+            version: string;
+          } | null> | null;
+        };
+      } | null> | null;
+    };
   } | null;
 };
 
@@ -251,30 +413,47 @@ export type PackagesByNameAndVersionPackageQuery = {
         files?: number | null;
       } | null;
     } | null;
-    suggestions: Array<{
-      __typename?: 'Suggestion';
-      id: string;
-      message: string;
-      actions: Array<{
-        __typename?: 'SuggestionAction';
+    suggestions: {
+      __typename?: 'SuggestionConnection';
+      nodes?: Array<{
+        __typename?: 'Suggestion';
+        id: string;
         message: string;
-        targetPackage?: { __typename?: 'Package'; id: string } | null;
-      } | null>;
-    } | null>;
+        actions: Array<{
+          __typename?: 'SuggestionAction';
+          message: string;
+          targetPackage?: { __typename?: 'Package'; id: string } | null;
+        } | null>;
+      } | null> | null;
+    };
   } | null;
 };
 
-export type PackagesPackagesQueryVariables = Exact<{ [key: string]: never }>;
+export type PackagesPackagesQueryVariables = Exact<{
+  first?: InputMaybe<Scalars['Int']>;
+  after?: InputMaybe<Scalars['String']>;
+}>;
 
 export type PackagesPackagesQuery = {
   __typename?: 'Query';
-  packages: Array<{
-    __typename?: 'Package';
-    id: string;
-    name: string;
-    version: string;
-    dependencyCount: number;
-  } | null>;
+  packages: {
+    __typename?: 'PackageConnection';
+    totalCount?: number | null;
+    nodes?: Array<{
+      __typename?: 'Package';
+      id: string;
+      name: string;
+      version: string;
+      dependencyCount: number;
+    } | null> | null;
+    pageInfo: {
+      __typename?: 'PageInfo';
+      endCursor?: string | null;
+      hasPreviousPage: boolean;
+      startCursor?: string | null;
+      hasNextPage: boolean;
+    };
+  };
 };
 
 export type SuggestionsByIdSuggestionQueryVariables = Exact<{
@@ -377,14 +556,16 @@ export const DetailsReportDocument = gql`
         name
         version
         dependencies {
-          id
-          name
-          version
-          type
-          metadata {
-            size {
-              files
-              physical
+          nodes {
+            id
+            name
+            version
+            type
+            metadata {
+              size {
+                files
+                physical
+              }
             }
           }
         }
@@ -449,15 +630,16 @@ export const IndexReportDocument = gql`
       root {
         name
         version
-        dependencies {
-          id
+      }
+      topSuggestions(first: 5) {
+        nodes {
+          ...IndexPageTopSuggestion
         }
       }
-      topSuggestions {
-        ...IndexPageTopSuggestion
-      }
-      suggestions {
-        ...CardViewSuggestions
+      suggestions(first: 10) {
+        nodes {
+          ...CardViewSuggestions
+        }
       }
     }
   }
@@ -518,13 +700,17 @@ export const PackageByNamePackageInfoDocument = gql`
       name
       latest
       variants {
-        id
-        version
-        name
-        parent {
+        nodes {
           id
-          name
           version
+          name
+          parent {
+            nodes {
+              id
+              name
+              version
+            }
+          }
         }
       }
     }
@@ -600,12 +786,14 @@ export const PackagesByNameAndVersionPackageDocument = gql`
         }
       }
       suggestions {
-        id
-        message
-        actions {
+        nodes {
+          id
           message
-          targetPackage {
-            id
+          actions {
+            message
+            targetPackage {
+              id
+            }
           }
         }
       }
@@ -665,12 +853,21 @@ export type PackagesByNameAndVersionPackageQueryResult = Apollo.QueryResult<
   PackagesByNameAndVersionPackageQueryVariables
 >;
 export const PackagesPackagesDocument = gql`
-  query PackagesPackages {
-    packages {
-      id
-      name
-      version
-      dependencyCount
+  query PackagesPackages($first: Int, $after: String) {
+    packages(first: $first, after: $after) {
+      totalCount
+      nodes {
+        id
+        name
+        version
+        dependencyCount
+      }
+      pageInfo {
+        endCursor
+        hasPreviousPage
+        startCursor
+        hasNextPage
+      }
     }
   }
 `;
@@ -687,6 +884,8 @@ export const PackagesPackagesDocument = gql`
  * @example
  * const { data, loading, error } = usePackagesPackagesQuery({
  *   variables: {
+ *      first: // value for 'first'
+ *      after: // value for 'after'
  *   },
  * });
  */

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -22,7 +22,7 @@
     "@emotion/styled": "^11.4.0",
     "@mui/icons-material": "^5.6.2",
     "@mui/material": "^5.7.0",
-    "@mui/x-data-grid": "^5.10.0",
+    "@mui/x-data-grid": "^5.12.0",
     "@nivo/core": "^0.79.0",
     "@nivo/treemap": "^0.79.1",
     "@package-inspector/core": "*",

--- a/packages/ui/pages/details.tsx
+++ b/packages/ui/pages/details.tsx
@@ -16,14 +16,16 @@ gql`
         name
         version
         dependencies {
-          id
-          name
-          version
-          type
-          metadata {
-            size {
-              files
-              physical
+          nodes {
+            id
+            name
+            version
+            type
+            metadata {
+              size {
+                files
+                physical
+              }
             }
           }
         }
@@ -41,7 +43,7 @@ const Report: NextPage = () => {
 
   const nivoData = {
     name: 'dependencies',
-    children: [...(data?.report?.root?.dependencies || [])].map(
+    children: [...(data?.report?.root?.dependencies?.nodes || [])].map(
       (dependency) => {
         if (!dependency) return {};
 
@@ -117,15 +119,17 @@ const Report: NextPage = () => {
                 { field: 'type', flex: 1 },
                 { field: 'size', flex: 1 },
               ]}
-              rows={data.report.root.dependencies.map((dep) => {
-                return {
-                  id: dep?.id,
-                  name: dep?.name,
-                  version: dep?.version,
-                  type: dep?.type,
-                  size: dep?.metadata?.size?.physical || 0,
-                };
-              })}
+              rows={
+                data.report.root.dependencies?.nodes?.map((dep) => {
+                  return {
+                    id: dep?.id,
+                    name: dep?.name,
+                    version: dep?.version,
+                    type: dep?.type,
+                    size: dep?.metadata?.size?.physical || 0,
+                  };
+                }) || []
+              }
               components={{ Toolbar: GridToolbar }}
             />
           </div>

--- a/packages/ui/pages/index.tsx
+++ b/packages/ui/pages/index.tsx
@@ -41,15 +41,16 @@ gql`
       root {
         name
         version
-        dependencies {
-          id
+      }
+      topSuggestions(first: 5) {
+        nodes {
+          ...IndexPageTopSuggestion
         }
       }
-      topSuggestions {
-        ...IndexPageTopSuggestion
-      }
-      suggestions {
-        ...CardViewSuggestions
+      suggestions(first: 10) {
+        nodes {
+          ...CardViewSuggestions
+        }
       }
     }
   }
@@ -122,7 +123,7 @@ const Home: NextPageWithLayout = () => {
               <br />
               <SuggestionOverview
                 summary={data.report.summary}
-                topSuggestions={data.report.topSuggestions}
+                topSuggestions={data.report.topSuggestions.nodes || []}
               />
             </Container>
           </Paper>
@@ -137,7 +138,7 @@ const Home: NextPageWithLayout = () => {
           justifyContent="center"
         >
           {data &&
-            data.report.suggestions.map((suggestion, idx) => {
+            data.report.suggestions?.nodes?.map((suggestion, idx) => {
               if (!suggestion) return <></>;
 
               const CustomCardView = pluginProvider?.cardView(

--- a/packages/ui/pages/packages/[name].tsx
+++ b/packages/ui/pages/packages/[name].tsx
@@ -13,13 +13,17 @@ gql`
       name
       latest
       variants {
-        id
-        version
-        name
-        parent {
+        nodes {
           id
-          name
           version
+          name
+          parent {
+            nodes {
+              id
+              name
+              version
+            }
+          }
         }
       }
     }
@@ -50,7 +54,7 @@ const Package: NextPage = () => {
     <>
       <h1>Package: {name}</h1>
       <h3>Versions:</h3>
-      {data.package?.variants?.map((variant) => {
+      {data.package?.variants?.nodes?.map((variant) => {
         return (
           <div key={variant?.id}>
             <NextLink
@@ -61,11 +65,11 @@ const Package: NextPage = () => {
               {variant?.version}
             </NextLink>
 
-            {(variant?.parent?.length || 0) > 0 ? (
+            {(variant?.parent?.nodes?.length || 0) > 0 ? (
               <>
                 <h3>Packages that depend on this</h3>
                 <ul>
-                  {variant?.parent.map((parent) => {
+                  {variant?.parent?.nodes?.map((parent) => {
                     return (
                       <li key={parent?.id}>
                         <NextLink

--- a/packages/ui/pages/packages/[name]/[version].tsx
+++ b/packages/ui/pages/packages/[name]/[version].tsx
@@ -24,12 +24,14 @@ gql`
         }
       }
       suggestions {
-        id
-        message
-        actions {
+        nodes {
+          id
           message
-          targetPackage {
-            id
+          actions {
+            message
+            targetPackage {
+              id
+            }
           }
         }
       }

--- a/packages/ui/pages/packages/index.tsx
+++ b/packages/ui/pages/packages/index.tsx
@@ -1,25 +1,73 @@
 import { gql } from '@apollo/client';
 import { Link } from '@mui/material';
-import { DataGrid, GridToolbar } from '@mui/x-data-grid';
+import { DataGrid } from '@mui/x-data-grid';
 import type { NextPage } from 'next';
 import NextLink from 'next/link';
+import { useEffect, useRef, useState } from 'react';
 
 import { LoadingView } from '../../components';
 import { usePackagesPackagesQuery } from '../../graphql/generated/client';
 
 gql`
-  query PackagesPackages {
-    packages {
-      id
-      name
-      version
-      dependencyCount
+  query PackagesPackages($first: Int, $after: String) {
+    packages(first: $first, after: $after) {
+      totalCount
+      nodes {
+        id
+        name
+        version
+        dependencyCount
+      }
+      pageInfo {
+        endCursor
+        hasPreviousPage
+        startCursor
+        hasNextPage
+      }
     }
   }
 `;
 
 const Packages: NextPage = () => {
-  const { data, loading, error } = usePackagesPackagesQuery();
+  const PAGE_SIZE = 100;
+
+  const mapPageToNextCursor = useRef<{ [page: number]: string }>({
+    0: 'null',
+  });
+
+  const [page, setPage] = useState(1);
+
+  const { data, loading, error } = usePackagesPackagesQuery({
+    variables: {
+      first: PAGE_SIZE,
+      after: mapPageToNextCursor.current[page],
+    },
+  });
+
+  console.log(data?.packages.pageInfo);
+
+  mapPageToNextCursor.current[page + 1] =
+    data?.packages.pageInfo.endCursor || 'null';
+
+  const [rowCountState, setRowCountState] = useState(
+    data?.packages?.totalCount || 0
+  );
+
+  useEffect(() => {
+    setRowCountState((prevRowCountState) =>
+      data?.packages?.totalCount !== undefined
+        ? data?.packages?.totalCount
+        : prevRowCountState || 0
+    );
+  }, [data?.packages?.totalCount, setRowCountState]);
+
+  const handlePageChange = (newPage: number) => {
+    if (data?.packages.pageInfo.hasNextPage) {
+      setPage(newPage);
+    }
+  };
+
+  console.log(data?.packages?.totalCount);
 
   if (loading) return <LoadingView />;
   if (error) return <p>Oh no... {error.message}</p>;
@@ -63,15 +111,23 @@ const Packages: NextPage = () => {
               },
               { field: 'count', flex: 1 },
             ]}
-            rows={data.packages.map((dep) => {
-              return {
-                id: dep?.id,
-                name: dep?.name,
-                version: dep?.version,
-                count: dep?.dependencyCount,
-              };
-            })}
-            components={{ Toolbar: GridToolbar }}
+            rows={
+              data.packages?.nodes?.map((dep) => {
+                return {
+                  id: dep?.id,
+                  name: dep?.name,
+                  version: dep?.version,
+                  count: dep?.dependencyCount,
+                };
+              }) || []
+            }
+            disableColumnFilter
+            disableColumnSelector
+            rowCount={rowCountState}
+            page={page}
+            pageSize={PAGE_SIZE}
+            paginationMode="server"
+            onPageChange={handlePageChange}
           />
         </div>
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1199,15 +1199,15 @@
   resolved "https://registry.yarnpkg.com/@mui/types/-/types-7.1.3.tgz#d7636f3046110bcccc63e6acfd100e2ad9ca712a"
   integrity sha512-DDF0UhMBo4Uezlk+6QxrlDbchF79XG6Zs0zIewlR4c0Dt6GKVFfUtzPtHCH1tTbcSlq/L2bGEdiaoHBJ9Y1gSA==
 
-"@mui/utils@^5.6.1":
-  version "5.6.1"
-  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.6.1.tgz#4ab79a21bd481555d9a588f4b18061b3c28ea5db"
-  integrity sha512-CPrzrkiBusCZBLWu0Sg5MJvR3fKJyK3gKecLVX012LULyqg2U64Oz04BKhfkbtBrPBbSQxM+DWW9B1c9hmV9nQ==
+"@mui/utils@^5.4.1":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@mui/utils/-/utils-5.8.0.tgz#4b1d19cbcf70773283375e763b7b3552b84cb58f"
+  integrity sha512-7LgUtCvz78676iC0wpTH7HizMdCrTphhBmRWimIMFrp5Ph6JbDFVuKS1CwYnWWxRyYKL0QzXrDL0lptAU90EXg==
   dependencies:
     "@babel/runtime" "^7.17.2"
-    "@types/prop-types" "^15.7.4"
+    "@types/prop-types" "^15.7.5"
     "@types/react-is" "^16.7.1 || ^17.0.0"
-    prop-types "^15.7.2"
+    prop-types "^15.8.1"
     react-is "^17.0.2"
 
 "@mui/utils@^5.7.0":
@@ -1221,12 +1221,13 @@
     prop-types "^15.8.1"
     react-is "^17.0.2"
 
-"@mui/x-data-grid@^5.10.0":
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/@mui/x-data-grid/-/x-data-grid-5.10.0.tgz#22917a8c1a6e95a2d3cde691f53071a838cba0e2"
-  integrity sha512-+NELUtA+6RAVFHR8sGrSxtJC8+3NQMLflYBm816DXjQvPA8vvCPI50SPKCUYUpBuepQtTBQWcty0Tdm9tjzInA==
+"@mui/x-data-grid@^5.12.0":
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/@mui/x-data-grid/-/x-data-grid-5.12.0.tgz#8cb9f610cdfa5dc3dd8f5d5bd62075f26f36cdd2"
+  integrity sha512-u9deMIa61HLs3WJKXaYPF7G1hBxcaW34etcUFsfdyS9GQDRtczM8Bad/QvxON8HKU61sbGVTHn1dLwVvRNFbZg==
   dependencies:
-    "@mui/utils" "^5.6.1"
+    "@babel/runtime" "^7.17.2"
+    "@mui/utils" "^5.4.1"
     clsx "^1.1.1"
     prop-types "^15.8.1"
     reselect "^4.1.5"
@@ -1755,7 +1756,7 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/prop-types@*", "@types/prop-types@^15.7.4", "@types/prop-types@^15.7.5":
+"@types/prop-types@*", "@types/prop-types@^15.7.5":
   version "15.7.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
@@ -4168,6 +4169,11 @@ graphql-executor@0.0.23:
   version "0.0.23"
   resolved "https://registry.yarnpkg.com/graphql-executor/-/graphql-executor-0.0.23.tgz#205c1764b39ee0fcf611553865770f37b45851a2"
   integrity sha512-3Ivlyfjaw3BWmGtUSnMpP/a4dcXCp0mJtj0PiPG14OKUizaMKlSEX+LX2Qed0LrxwniIwvU6B4w/koVjEPyWJg==
+
+graphql-relay@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/graphql-relay/-/graphql-relay-0.10.0.tgz#3b661432edf1cb414cd4a132cf595350e524db2b"
+  integrity sha512-44yBuw2/DLNEiMypbNZBt1yMDbBmyVPVesPywnteGGALiBmdyy1JP8jSg8ClLePg8ZZxk0O4BLhd1a6U/1jDOQ==
 
 graphql-request@^4.0.0:
   version "4.2.0"


### PR DESCRIPTION
fixes #49 

# before

> 28.3kb, 2.7s

<img width="1772" alt="Screen Shot 2022-05-31 at 10 50 30 PM" src="https://user-images.githubusercontent.com/1854811/171336657-e115a5f0-3009-40db-910e-232acd85b39b.png">


# after

> 2.4kb, 25ms

<img width="1772" alt="Screen Shot 2022-05-31 at 10 47 48 PM" src="https://user-images.githubusercontent.com/1854811/171336516-271551e7-e3d2-4404-81dc-c766898a1c40.png">

