### PR TITLE
fix: top-level-deps-freshness support for workspaces

### DIFF
--- a/packages/core/src/report/generate-report.ts
+++ b/packages/core/src/report/generate-report.ts
@@ -1,4 +1,5 @@
 import Arborist from '@npmcli/arborist';
+import fs from 'fs-extra';
 import path from 'path';
 
 import { Report } from '../models';
@@ -71,7 +72,9 @@ export async function generateReport(
     const lookupKey = `${depNode.name}@${depNode.version}`;
 
     if (!report.dependencies[lookupKey]) {
-      const { devDependencies } = require(`${depNode.realpath}/package.json`);
+      const { devDependencies } = fs.readJSONSync(
+        `${depNode.realpath}/package.json`
+      );
 
       report.dependencies[lookupKey] = {
         funding: depNode.funding,

--- a/packages/plugin-preset/src/suggestors/top-level-deps-freshness.ts
+++ b/packages/plugin-preset/src/suggestors/top-level-deps-freshness.ts
@@ -1,6 +1,8 @@
 import {
   type Suggestion,
   getLatestPackages,
+  SuggestionAction,
+  SuggestionInput,
   SuggestionTask,
 } from '@package-inspector/core';
 import debug from 'debug';
@@ -78,7 +80,7 @@ export class TopLevelDepsFreshness extends SuggestionTask {
     const latestPackages = await getLatestPackages(arboristValues);
 
     if (rootArboristNode?.edgesOut) {
-      for (const [, edge] of rootArboristNode?.edgesOut) {
+      for (const [, edge] of rootArboristNode.edgesOut) {
         // we will need to iterate through the workspace deps to get the most update information
         if (edge.type === 'workspace') {
           if (edge.to.package.devDependencies) {

--- a/packages/ui/graphql/generated/client.ts
+++ b/packages/ui/graphql/generated/client.ts
@@ -108,6 +108,7 @@ export type Suggestion = {
 export type SuggestionAction = {
   __typename?: 'SuggestionAction';
   message: Scalars['String'];
+  priority?: Maybe<Scalars['Int']>;
   targetPackage?: Maybe<Package>;
   targetPackageId: Scalars['String'];
 };

--- a/packages/ui/graphql/generated/client.ts
+++ b/packages/ui/graphql/generated/client.ts
@@ -108,7 +108,6 @@ export type Suggestion = {
 export type SuggestionAction = {
   __typename?: 'SuggestionAction';
   message: Scalars['String'];
-  priority?: Maybe<Scalars['Int']>;
   targetPackage?: Maybe<Package>;
   targetPackageId: Scalars['String'];
 };


### PR DESCRIPTION
When running package-inspector against itself, I found that we don't take into account workspaces when running top-level-dep-freshness. I have also updated the text to take into consideration what happens if we encounter a dep of a workspace.

# before 
<img width="952" alt="Screen Shot 2022-06-01 at 1 24 33 AM" src="https://user-images.githubusercontent.com/1854811/171362469-c7dfd7af-7b3f-43f0-a906-509b2bf99b2a.png">

# after

<img width="952" alt="Screen Shot 2022-06-01 at 1 42 46 AM" src="https://user-images.githubusercontent.com/1854811/171364471-77bfcb69-efd0-4009-b7e8-7aeb456ab09f.png">

